### PR TITLE
Reformat URL tags to Django 1.3 style, which is required for Django 1.5 compatibility; block editor backup files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ virtualenv
 
 #Mr Developer
 .mr.developer.cfg
+
+# text editors
+*~
+*.swp

--- a/wiki/templates/wiki/base.html
+++ b/wiki/templates/wiki/base.html
@@ -1,4 +1,4 @@
-{% load sekizai_tags %}<!DOCTYPE html>
+{% load sekizai_tags %}{% load url from future %}<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -49,7 +49,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="{% url wiki:root %}">django-wiki</a>
+          <a class="brand" href="{% url 'wiki:root' %}">django-wiki</a>
           <div class="nav-collapse">
             <ul class="nav">
               <li class="active"><a href="#">Home</a></li>

--- a/wiki/templates/wiki/create.html
+++ b/wiki/templates/wiki/create.html
@@ -1,5 +1,6 @@
 {% extends "wiki/base.html" %}
 {% load wiki_tags i18n sekizai_tags %}
+{% load url from future %}
 
 {% block pagetitle %}{% trans "Add new article" %}{% endblock %}
 
@@ -10,7 +11,7 @@
   <form method="POST" class="form-horizontal">
     {% wiki_form create_form %}
     <div class="form-actions">
-        <a href="{% url wiki:get_url parent_urlpath.path %}" class="btn btn-large">
+        <a href="{% url 'wiki:get_url' parent_urlpath.path %}" class="btn btn-large">
           <span class="icon-circle-arrow-left"></span>
           {% trans "Go back" %}
         </a>

--- a/wiki/templates/wiki/edit.html
+++ b/wiki/templates/wiki/edit.html
@@ -1,5 +1,6 @@
 {% extends "wiki/base.html" %}
 {% load wiki_tags i18n %}
+{% load url from future %}
 
 {% block pagetitle %}{% trans "Edit" %}: {% article_for_object urlpath as article %}{{ article.current_revision.title }}{% endblock %}
 
@@ -28,11 +29,11 @@
         <form method="POST" class="form-horizontal">
           {% include "wiki/includes/editor.html" %}
           <div class="form-actions">
-              <button type="submit" name="preview" value="1" class="btn btn-large" onclick="$('#previewModal').modal('show'); this.form.target='previewWindow'; this.form.action='{% url wiki:preview_url urlpath.path %}'">
+              <button type="submit" name="preview" value="1" class="btn btn-large" onclick="$('#previewModal').modal('show'); this.form.target='previewWindow'; this.form.action='{% url 'wiki:preview_url' urlpath.path %}'">
                 <span class="icon-eye-open"></span>
                 {% trans "Preview" %}
               </button>
-              <button type="submit" name="save" value="1" class="btn btn-large btn-primary" onclick="this.form.target=''; this.form.action='{% url wiki:edit_url urlpath.path %}'">
+              <button type="submit" name="save" value="1" class="btn btn-large btn-primary" onclick="this.form.target=''; this.form.action='{% url 'wiki:edit_url' urlpath.path %}'">
                 <span class="icon-ok"></span>
                 {% trans "Save changes" %}
               </button>
@@ -52,7 +53,7 @@
                 <span class="icon-circle-arrow-left"></span>
                 {% trans "Back to editor" %}
               </a>
-              <button type="submit" name="save" value="1" class="btn btn-large btn-primary" onclick="this.form.target=''; this.form.action='{% url wiki:edit_url urlpath.path %}'">
+              <button type="submit" name="save" value="1" class="btn btn-large btn-primary" onclick="this.form.target=''; this.form.action='{% url 'wiki:edit_url' urlpath.path %}'">
                 <span class="icon-ok"></span>
                 {% trans "Save changes" %}
               </button>

--- a/wiki/templates/wiki/history.html
+++ b/wiki/templates/wiki/history.html
@@ -1,5 +1,6 @@
 {% extends "wiki/base.html" %}
 {% load wiki_tags i18n sekizai_tags %}
+{% load url from future %}
 
 {% block pagetitle %}{% trans "History" %}: {% article_for_object urlpath as article %}{{ article.current_revision.title }}{% endblock %}
 
@@ -76,7 +77,7 @@
             <div class="accordion" id="accordion{{ revision.revision_number }}">
               <div class="accordion-group">
                 <div class="accordion-heading">
-                  <a class="accordion-toggle" style="float: left;" href="#collapse{{ revision.revision_number }}" onclick="get_diff_json('{% url wiki:diff revision.id %}', $('#collapse{{ revision.revision_number }}'))">
+                  <a class="accordion-toggle" style="float: left;" href="#collapse{{ revision.revision_number }}" onclick="get_diff_json('{% url 'wiki:diff' revision.id %}', $('#collapse{{ revision.revision_number }}'))">
                     {{ revision.created }} (#{{ revision.revision_number }}) by {% if revision.user %}{{ revision.user }}{% else %}{% if user.is_superuser %}{{ revision.ip_address|default:"anonymous (IP not logged)" }}{% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
                     {% if revision == article.current_revision %}
                       <strong>*</strong>
@@ -92,17 +93,17 @@
                       {% trans "Preview this version" %}
                     </a>
                     {% else %}
-                    <button type="submit" class="btn" onclick="$('#previewModal').modal('show'); this.form.target='previewWindow'; this.form.action='{% url wiki:preview_revision article.id %}'; $('#previewModal .switch-to-revision').attr('href', '{% url wiki:change_revision_url urlpath.path revision.id %}')">
+                    <button type="submit" class="btn" onclick="$('#previewModal').modal('show'); this.form.target='previewWindow'; this.form.action='{% url 'wiki:preview_revision' article.id %}'; $('#previewModal .switch-to-revision').attr('href', '{% url 'wiki:change_revision_url' urlpath.path revision.id %}')">
                       <span class="icon-eye-open"></span>
                       {% trans "Preview this version" %}
                     </button>
                     {% endif %}
-                    <a class="btn btn-info" href="#collapse{{ revision.revision_number }}" onclick="get_diff_json('{% url wiki:diff revision.id %}', $('#collapse{{ revision.revision_number }}'))">
+                    <a class="btn btn-info" href="#collapse{{ revision.revision_number }}" onclick="get_diff_json('{% url 'wiki:diff' revision.id %}', $('#collapse{{ revision.revision_number }}'))">
                       <span class="icon-list-alt"></span>
                       {% trans "Show changes" %}
                     </a>
                     
-                    <input type="radio"{% if revision == article.current_revision %} disabled="true"{% endif %} style="margin: 0 10px;" value="{{ revision.id }}" name="revision_id" switch-button-href="{% url wiki:change_revision_url urlpath.path revision.id %}" merge-button-href="{% url wiki:merge_revision_preview article.id revision.id %}" merge-button-commit-href="{% url wiki:merge_revision_url urlpath.path revision.id %}" />
+                    <input type="radio"{% if revision == article.current_revision %} disabled="true"{% endif %} style="margin: 0 10px;" value="{{ revision.id }}" name="revision_id" switch-button-href="{% url 'wiki:change_revision_url' urlpath.path revision.id %}" merge-button-href="{% url 'wiki:merge_revision_preview' article.id revision.id %}" merge-button-commit-href="{% url 'wiki:merge_revision_url' urlpath.path revision.id %}" />
                     
                   </div>
                   <div style="clear: both"></div>

--- a/wiki/templates/wiki/includes/article_menu.html
+++ b/wiki/templates/wiki/includes/article_menu.html
@@ -1,27 +1,27 @@
-{% load i18n wiki_tags %}
+{% load i18n wiki_tags %}{% load url from future %}
 
 <li class="pull-right{% if selected == "settings" %} active{% endif %}">
   {% if not user.is_anonymous %}
-  <a href="{% url wiki:settings_url urlpath.path %}">
+  <a href="{% url 'wiki:settings_url' urlpath.path %}">
     <span class="icon-wrench"></span>
     {% trans "Settings" %}
   </a>
   {% endif %}
 </li>
 <li class="pull-right{% if selected == "history" %} active{% endif %}">
-  <a href="{% url wiki:history_url urlpath.path %}">
+  <a href="{% url 'wiki:history_url' urlpath.path %}">
     <span class="icon-time"></span>
     {% trans "Changes" %}
   </a>
 </li>
 <li class="pull-right{% if selected == "edit" %} active{% endif %}">
-  <a href="{% url wiki:edit_url urlpath.path %}">
+  <a href="{% url 'wiki:edit_url' urlpath.path %}">
     <span class="icon-edit"></span>
     {% trans "Edit" %}
   </a>
 </li>
 <li class="pull-right{% if selected == "view" %} active{% endif %}">
-  <a href="{% url wiki:get_url urlpath.path %}">
+  <a href="{% url 'wiki:get_url' urlpath.path %}">
     <span class="icon-home"></span>
     {% trans "View" %}
   </a>

--- a/wiki/templates/wiki/includes/breadcrumbs.html
+++ b/wiki/templates/wiki/includes/breadcrumbs.html
@@ -1,11 +1,11 @@
-{% load i18n %}<ul class="breadcrumb">
+{% load i18n %}{% load url from future %}<ul class="breadcrumb">
   {% for ancestor in urlpath.get_ancestors.all %}
     <span class="divider">/</span>
-    <a href="{% url wiki:get_url ancestor.path %}"><li>{{ ancestor.article.current_revision.title }}</li></a>
+    <a href="{% url 'wiki:get_url' ancestor.path %}"><li>{{ ancestor.article.current_revision.title }}</li></a>
   {% endfor %}
   <span class="divider">/</span>
-  <li class="active"><a href="{% url wiki:get_url urlpath.path %}">{{ urlpath.article.current_revision.title }}</a></li>
+  <li class="active"><a href="{% url 'wiki:get_url' urlpath.path %}">{{ urlpath.article.current_revision.title }}</a></li>
   <span class="divider">/</span>
-  <li><a href="{% url wiki:create_url urlpath.path %}">{% trans "+ Add article" %}</a></li>
+  <li><a href="{% url 'wiki:create_url' urlpath.path %}">{% trans "+ Add article" %}</a></li>
 </ul>
 

--- a/wiki/templates/wiki/settings.html
+++ b/wiki/templates/wiki/settings.html
@@ -1,5 +1,6 @@
 {% extends "wiki/base.html" %}
 {% load wiki_tags i18n %}
+{% load url from future %}
 
 {% block pagetitle %}{% trans "Settings" %}: {% article_for_object urlpath as article %}{{ article.current_revision.title }}{% endblock %}
 
@@ -32,7 +33,7 @@
             {% wiki_form form %}
           </div>
           <div class="form-actions">
-            <button type="submit" name="save" value="1" class="btn btn-large btn-primary" onclick="this.form.target=''; this.form.action='{% url wiki:edit_url urlpath.path %}'">
+            <button type="submit" name="save" value="1" class="btn btn-large btn-primary" onclick="this.form.target=''; this.form.action='{% url 'wiki:edit_url' urlpath.path %}'">
               <span class="icon-ok"></span>
               {% trans "Save changes" %}
             </button>


### PR DESCRIPTION
This pull request addresses two issues:
- The `{% url %}` tag in Django 1.5 (in development) requires you use Django 1.3's new URL tag syntax.  I've ported all the template URL tag use to this new format and added the `load url from future` compatibility tag so that it would continue to work on Django 1.3 and 1.4.

The new syntax is described here: https://docs.djangoproject.com/en/dev/releases/1.3/#changes-to-url-and-ssi
- When fixing this bug, I noticed that some editor backup files were not blocked by `.gitignore`.  I've added those.
