### PR TITLE
Fixed WikiPath regexp. It was incorrectly matching [Title](Link) on the ...

### DIFF
--- a/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/wiki/plugins/links/mdx/djangowikilinks.py
@@ -49,7 +49,7 @@ class WikiPathExtension(markdown.Extension):
         self.md = md
         
         # append to end of inline patterns
-        WIKI_RE =  r'\[(?P<linkTitle>.+?)\]\(wiki:(?P<wikiTitle>[a-zA-Z\d\./_-]*)\)'
+        WIKI_RE =  r'\[(?P<linkTitle>[^\]]+?)\]\(wiki:(?P<wikiTitle>[a-zA-Z\d\./_-]*)\)'
         wikiPathPattern = WikiPath(WIKI_RE, self.config, markdown_instance=md)
         wikiPathPattern.md = md
         md.inlinePatterns.add('djangowikipath', wikiPathPattern, "<reference")


### PR DESCRIPTION
 A line with a [Title](Link) [Title](wiki:Link) was matching incorrectly
