### PR TITLE
Fix image captions in the case when there are at least two captioned images

### DIFF
--- a/wiki/plugins/images/markdown_extensions.py
+++ b/wiki/plugins/images/markdown_extensions.py
@@ -40,6 +40,7 @@ class ImagePreprocessor(markdown.preprocessors.Preprocessor):
                 except models.Image.DoesNotExist:
                     pass
                 line = line.replace(m.group(1), "")
+                caption_lines = []
             elif previous_line_was_image:
                 if line.startswith("    "):
                     caption_lines.append(line[4:])


### PR DESCRIPTION
Reset caption_lines for each image.  Without this, the n-th image is captioned with the concatenation of the first n captions.
