### PR TITLE
Fix select_related_common call on EmptyQuerySet (Django 1.5/master), minor optimisation on ACLs (use .exists() instead of bool())

### DIFF
--- a/wiki/models/article.py
+++ b/wiki/models/article.py
@@ -57,7 +57,7 @@ class Article(models.Model):
         if user == self.owner:
             return True
         if self.group_read:
-            if self.group and user.groups.filter(id=self.group.id):
+            if self.group and user.groups.filter(id=self.group.id).exists():
                 return True
         if self.can_moderate(user):
             return True
@@ -74,7 +74,7 @@ class Article(models.Model):
         if user == self.owner:
             return True
         if self.group_write:
-            if self.group and user and user.groups.filter(id=self.group.id):
+            if self.group and user and user.groups.filter(id=self.group.id).exists():
                 return True
         if self.can_moderate(user):
             return True

--- a/wiki/models/urlpath.py
+++ b/wiki/models/urlpath.py
@@ -60,6 +60,8 @@ class URLPath(MPTTModel):
         If the cached ancestors were not set explicitly, they will be retrieved from
         the database.
         """
+        if not self.get_ancestors().exists():
+            self._cached_ancestors = []
         if not hasattr(self, "_cached_ancestors"):
             self._cached_ancestors = list(self.get_ancestors().select_related_common() )
         


### PR DESCRIPTION
I did a bunch of work on ACLs, then realised I hadn't merged upstream properly. :(

As a result, I've discarded the work I did on this, and now I'm properly aligned with master.  The code that was written wasn't much different, however my version did use .exists() on the group query rather than evaluating it to a bool(), which makes it a little faster (it means that you're no longer grabbing a complete copy of a group if a user belongs to that group).

I also identified an issue in URLPath on Django 1.5, in EmptyQuerySet has no select_related_common().  I've added some extra code to take care of this situation so it will cache an empty list in this case.  Django 1.5 returns EmptyQuerySet instead of a complete QuerySet object when there are no results to a query, and it appears the custom manager objects aren't used in this case.
