### PR TITLE
Fix for makemessages error for line 561 in views/articles.py

### DIFF
--- a/wiki/views/article.py
+++ b/wiki/views/article.py
@@ -558,7 +558,7 @@ def change_revision(request, article, revision_id=None, urlpath=None):
     revision = get_object_or_404(models.ArticleRevision, article=article, id=revision_id)
     article.current_revision = revision
     article.save()
-    messages.success(request, _(u"The article #%(title)s is now set to display revision #%(revision_number)d") % {'title':revision.title, 'revision_number': revision.revision_number,})
+    messages.success(request, _(u"The article %(title)s is now set to display revision #%(revision_number)d") % {'title':revision.title, 'revision_number': revision.revision_number,})
 
     if urlpath:
         return redirect("wiki:history", path=urlpath.path)


### PR DESCRIPTION
The translator cannot reorder the arguments.
Please consider using a format string with named arguments, and a
mapping instead of a tuple for the arguments.
