### PR TITLE
Using Greedy algorithm for links regex expression

### DIFF
--- a/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/wiki/plugins/links/mdx/djangowikilinks.py
@@ -48,7 +48,7 @@ class WikiPathExtension(markdown.Extension):
         self.md = md
         
         # append to end of inline patterns
-        WIKI_RE =  r'\[(?P<linkTitle>[^\]]+?)\]\(wiki:(?P<wikiTitle>[a-zA-Z\d\./_-]*)\)'
+        WIKI_RE =  r'\[(?P<linkTitle>[^\]]+?)\]\(wiki:(?P<wikiTitle>[a-zA-Z\d\./_-]*?)\)'
         wikiPathPattern = WikiPath(WIKI_RE, self.config, markdown_instance=md)
         wikiPathPattern.md = md
         md.inlinePatterns.add('djangowikipath', wikiPathPattern, "<reference")


### PR DESCRIPTION
If you had two or more link in one line, current regex expression will catch all characters between first "(" and last  ")" links as a link title.

We need to use greedy  quantifier "?"  to avoid such behavior
