### PR TITLE
Notifications Plugin form fails to import ARTICLE_EDIT

### DIFF
--- a/wiki/plugins/notifications/forms.py
+++ b/wiki/plugins/notifications/forms.py
@@ -5,7 +5,7 @@ from django_notify.models import Settings, NotificationType
 from django.contrib.contenttypes.models import ContentType
 from django.utils.safestring import mark_safe
 
-from wiki.plugins.notifications import ARTICLE_EDIT
+from wiki.plugins.notifications.settings import ARTICLE_EDIT
 from wiki.core.plugins.base import PluginSettingsFormMixin
 
 class SubscriptionForm(PluginSettingsFormMixin, forms.Form):


### PR DESCRIPTION
After the commit to truncate long notifications, the key for the 
article notification was moved to a settings file.

No error or exception is being generated when forms.py
fails to import ARTICLE_EDIT (?). 
This causes that the plugin is not shown on the configuration for 
articles.
