### PR TITLE
Update readme dependencies (Closes: #77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Dependencies
 
 So far the dependencies are:
 
- * [django=>1.4](http://www.djangoproject.com)
+ * [django>=1.4](http://www.djangoproject.com)
  * [django-south](http://south.aeracode.org/)
  * [Markdown>=2.2.0](https://github.com/waylan/Python-Markdown)
  * [django-mptt>=0.5.3](https://github.com/django-mptt/django-mptt)


### PR DESCRIPTION
I tried django-wiki and needed django-mptt 0.5.3.

Also fixed invariant typo for django version dependency.
