### PR TITLE
Fixed typo in admin - Article revision list columns

### DIFF
--- a/wiki/admin.py
+++ b/wiki/admin.py
@@ -26,7 +26,7 @@ class ArticleRevisionForm(forms.ModelForm):
 
 class ArticleRevisionAdmin(admin.ModelAdmin):
     form = ArticleRevisionForm
-    display_list = ('title', 'created', 'modified', 'user', 'ip_address')
+    list_display = ('title', 'created', 'modified', 'user', 'ip_address')
     class Media:
         js = editors.getEditorClass().AdminMedia.js
         css = editors.getEditorClass().AdminMedia.css


### PR DESCRIPTION
The old name "display_list" does not mean anything in Django.
