### PR TITLE
adding PIL pre-req documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Django-wiki uses the [PIL library](http://www.pythonware.com/products/pil/) for 
 
 **Ubuntu/Apt-based Linux Distros**
 
-    sudo apt-get install libjpeg-dev
+    sudo apt-get install python-imaging
 
 **Mac OS X 10.5+**
 


### PR DESCRIPTION
Without libjpeg PIL won't be able to install with jpeg support and users will see IOErrors on their wikis.  Highlighting this in a "prerequisites" section on the README.

Documentation now has a little bit of background as well as installation instructions for Linux/OS X.
