### PR TITLE
Don't change the slug when entering a title

### DIFF
--- a/wiki/templates/wiki/create.html
+++ b/wiki/templates/wiki/create.html
@@ -22,6 +22,7 @@
       s = s.toLowerCase();             // convert to lowercase
       return s.substring(0, num_chars);// trim to first num_chars chars
   }
+  {% if not create_form.slug.value %}
   //<![CDATA[	
   (function($) {
 	  $(document).ready(function (){
@@ -38,6 +39,7 @@
 	  });
   })(jQuery);
   //]]>
+  {% endif %}
   </script>
   {% endaddtoblock %}
 


### PR DESCRIPTION
I found this problem quite annoying:
When entering a title for an article, the slug dynamically gets updated. This is useful, when creating a new article for which the slug is still unknown. In case however we create a new article and the slug is already known (e.g. by linking the new article and then clicking on it), this might destroy the link.

In my pull request, the javascript for that only is loaded in case we don't know a slug yet.
