### PR TITLE
Initialize std.out stream handler compatible with Python 2.6

### DIFF
--- a/django_notify/management/commands/notifymail.py
+++ b/django_notify/management/commands/notifymail.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
             if daemon:
                 handler = logging.FileHandler(filename=notify_settings.NOTIFY_LOG)
             else:
-                handler = logging.StreamHandler(stream=self.stdout)
+                handler = logging.StreamHandler(self.stdout)
             self.logger.addHandler(handler)
             self.logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
When starting `notifymail` command in Python 2.6 environment it fails by reporting:

> TypeError: **init**() got an unexpected keyword argument 'stream'

StreamHandler's `stream` kwarg isn't available in Python 2.6 (it's `strm`)
Replacing call with positional argument (omitting argument's name).
