### PR TITLE
Use a private instance of sorl.thumbnails.

### DIFF
--- a/wiki/plugins/images/templates/wiki/plugins/images/index.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/index.html
@@ -1,5 +1,5 @@
 {% extends "wiki/article.html" %}
-{% load wiki_tags i18n humanize thumbnail %}
+{% load wiki_tags i18n humanize wiki_thumbnails %}
 {% load url from future %}
 
 {% block wiki_pagetitle %}{% trans "Images" %}: {{ article.current_revision.title }}{% endblock %}

--- a/wiki/plugins/images/templates/wiki/plugins/images/purge.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/purge.html
@@ -1,5 +1,5 @@
 {% extends "wiki/article.html" %}
-{% load wiki_tags i18n humanize thumbnail %}
+{% load wiki_tags i18n humanize wiki_thumbnails %}
 {% load url from future %}
 
 {% block wiki_pagetitle %}{% trans "Purge deletion" %}: {{ image }}{% endblock %}

--- a/wiki/plugins/images/templates/wiki/plugins/images/render.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/render.html
@@ -1,4 +1,4 @@
-{% load thumbnail i18n %}{% comment %}
+{% load wiki_thumbnails i18n %}{% comment %}
   This template is used for the markdown extension that renders images and captions.
   
   NB! Watch out for line breaks, markdown might add <br />s and <p>s.

--- a/wiki/plugins/images/templates/wiki/plugins/images/revision_add.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/revision_add.html
@@ -1,5 +1,5 @@
 {% extends "wiki/article.html" %}
-{% load wiki_tags i18n humanize thumbnail %}
+{% load wiki_tags i18n humanize wiki_thumbnails %}
 {% load url from future %}
 
 {% block wiki_pagetitle %}{% trans "Replace image" %}: {{ image }}{% endblock %}

--- a/wiki/plugins/images/templates/wiki/plugins/images/sidebar.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/sidebar.html
@@ -1,4 +1,4 @@
-{% load i18n wiki_tags wiki_images_tags humanize thumbnail sekizai_tags %}
+{% load i18n wiki_tags wiki_images_tags humanize wiki_thumbnails sekizai_tags %}
 {% load url from future %}
 
 {% addtoblock "js" %}

--- a/wiki/plugins/images/templatetags/wiki_thumbnails.py
+++ b/wiki/plugins/images/templatetags/wiki_thumbnails.py
@@ -1,0 +1,1 @@
+from sorl.thumbnail.templatetags.thumbnail import register


### PR DESCRIPTION
 Allows django-wiki to use sorl.thumbnail when easy_thumbnails is also installed and appears first in INSTALLED_APPS.
