### PR TITLE
Make custom permissions loaded from module

### DIFF
--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -37,6 +37,15 @@ LOG_IPS_USERS = getattr( django_settings, 'WIKI_LOG_IPS_USERS', False )
 # NB! None of these callables need to handle anonymous users as they are treated
 # in separate settings...
 
+# Permissions module loaded dynamically
+# This file may contain any permission you want to override
+# can_read, can_write, can_assign, can_assign_owner, 
+# can_change_permissions, can_delete, can_moderate, can_admin
+# In your settings use for example
+# WIKI_PERMISSIONS_MODULE = 'my_app.permssions' 
+# If you have defined your functions in permissions.py in 'my_app'
+PERMISSIONS_MODULE = getattr( django_settings, 'WIKI_PERMISSIONS_MODULE', None )
+
 # A function returning True/False if a user has permission to
 # read contents of an article + plugins
 # Relevance: viewing articles and plugins

--- a/wiki/core/permissions.py
+++ b/wiki/core/permissions.py
@@ -14,7 +14,12 @@ from wiki.conf import settings
 def can_read(article, user):
     if callable(settings.CAN_READ):
         return settings.CAN_READ(article, user)
-    else:
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_read(article, user)        
+    except:
         # Deny reading access to deleted articles if user has no delete access
         article_is_deleted = article.current_revision and article.current_revision.deleted
         if article_is_deleted and not article.can_delete(user):
@@ -39,54 +44,96 @@ def can_read(article, user):
 def can_write(article, user):
     if callable(settings.CAN_WRITE):
         return settings.CAN_WRITE(article, user)
-    # Check access for other users...
-    if user.is_anonymous() and not settings.ANONYMOUS_WRITE:
-        return False
-    elif article.other_write:
-        return True
-    elif user.is_anonymous():
-        return  False
-    if user == article.owner:
-        return True
-    if article.group_write:
-        if article.group and user and user.groups.filter(id=article.group.id).exists():
-            return True
-    if article.can_moderate(user):
-        return True
-    return False
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_write(article, user)        
+    except:
+      # Check access for other users...
+      if user.is_anonymous() and not settings.ANONYMOUS_WRITE:
+          return False
+      elif article.other_write:
+          return True
+      elif user.is_anonymous():
+          return  False
+      if user == article.owner:
+          return True
+      if article.group_write:
+          if article.group and user and user.groups.filter(id=article.group.id).exists():
+              return True
+      if article.can_moderate(user):
+          return True
+      return False
 
 def can_assign(article, user):
     if callable(settings.CAN_ASSIGN):
         return settings.CAN_ASSIGN(article, user)
-    return not user.is_anonymous() and user.has_perm('wiki.assign')
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_assign(article, user)        
+    except:
+      return not user.is_anonymous() and user.has_perm('wiki.assign')
 
 def can_assign_owner(article, user):
     if callable(settings.CAN_ASSIGN_OWNER):
         return settings.CAN_ASSIGN_OWNER(article, user)
-    return False
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_assign_owner(article, user)        
+    except:
+      return False
 
 def can_change_permissions(article, user):
     if callable(settings.CAN_CHANGE_PERMISSIONS):
         return settings.CAN_CHANGE_PERMISSIONS(article, user)
-    return (
-        not user.is_anonymous() and (
-            article.owner == user or 
-            user.has_perm('wiki.assign')
-        )
-    )
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_change_permissions(article, user)        
+    except:
+      return (
+          not user.is_anonymous() and (
+              article.owner == user or 
+              user.has_perm('wiki.assign')
+          )
+      )
 
 def can_delete(article, user):
     if callable(settings.CAN_DELETE):
         return settings.CAN_DELETE(article, user)
-    return not user.is_anonymous() and article.can_write(user)
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_delete(article, user)        
+    except:
+      return not user.is_anonymous() and article.can_write(user)
 
 def can_moderate(article, user):
     if callable(settings.CAN_MODERATE):
         return settings.CAN_MODERATE(article, user)
-    return not user.is_anonymous() and user.has_perm('wiki.moderate')
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_moderate(article, user)        
+    except:
+      return not user.is_anonymous() and user.has_perm('wiki.moderate')
 
 def can_admin(article, user):
     if callable(settings.CAN_ADMIN):
         return settings.CAN_ADMIN(article, user)
-    return not user.is_anonymous() and user.has_perm('wiki.admin')
+    try:       
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        return per.can_admin(article, user)        
+    except:
+      return not user.is_anonymous() and user.has_perm('wiki.admin')
 

--- a/wiki/core/permissions.py
+++ b/wiki/core/permissions.py
@@ -1,5 +1,25 @@
 from wiki.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 import imp
+
+
+if settings.PERMISSIONS_MODULE:
+    try:
+        module_name = settings.PERMISSIONS_MODULE
+        m = module_name.split('.')
+        per = imp.load_source(module_name, m[0])
+        
+        #Helper for app loading order problem.
+        if (not hasattr(per, 'can_read') and not hasattr(per, 'can_write') and not hasattr(per, 'can_admin') and
+                not hasattr(per, 'can_can_delete') and not hasattr(per, 'can_moderate') and
+                not hasattr(per, 'can_assign') and not hasattr(per, 'can_assign_owner') and 
+                not hasattr(per, 'can_change_permissions')):
+            raise ImproperlyConfigured('django-wiki: No function was found in your PERMISSIONS_MODULE file. It might be because the app it depends on is no yet loaded. Check app loading order.')
+    
+    except IOError:
+        raise ImproperlyConfigured('django-wiki: Your PERMISSIONS_MODULE file does not seem to exists.')
+
+
 
 ###############################
 # ARTICLE PERMISSION HANDLING #
@@ -15,12 +35,9 @@ import imp
 def can_read(article, user):
     if callable(settings.CAN_READ):
         return settings.CAN_READ(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+    elif hasattr(per, 'can_read'):
         return per.can_read(article, user)        
-    except:
+    else:
         # Deny reading access to deleted articles if user has no delete access
         article_is_deleted = article.current_revision and article.current_revision.deleted
         if article_is_deleted and not article.can_delete(user):
@@ -45,96 +62,75 @@ def can_read(article, user):
 def can_write(article, user):
     if callable(settings.CAN_WRITE):
         return settings.CAN_WRITE(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
-        return per.can_write(article, user)        
-    except:
-      # Check access for other users...
-      if user.is_anonymous() and not settings.ANONYMOUS_WRITE:
-          return False
-      elif article.other_write:
-          return True
-      elif user.is_anonymous():
-          return  False
-      if user == article.owner:
-          return True
-      if article.group_write:
-          if article.group and user and user.groups.filter(id=article.group.id).exists():
-              return True
-      if article.can_moderate(user):
-          return True
-      return False
+    elif hasattr(per, 'can_write'):
+        return per.can_write(article, user)         
+    else:
+        # Check access for other users...
+        if user.is_anonymous() and not settings.ANONYMOUS_WRITE:
+            return False
+        elif article.other_write:
+            return True
+        elif user.is_anonymous():
+            return  False
+        if user == article.owner:
+            return True
+        if article.group_write:
+            if article.group and user and user.groups.filter(id=article.group.id).exists():
+                return True
+        if article.can_moderate(user):
+            return True
+        return False
 
 def can_assign(article, user):
     if callable(settings.CAN_ASSIGN):
         return settings.CAN_ASSIGN(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+    elif hasattr(per, 'can_assign'):
         return per.can_assign(article, user)        
-    except:
-      return not user.is_anonymous() and user.has_perm('wiki.assign')
+    else:
+        return not user.is_anonymous() and user.has_perm('wiki.assign')
 
 def can_assign_owner(article, user):
     if callable(settings.CAN_ASSIGN_OWNER):
         return settings.CAN_ASSIGN_OWNER(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+    elif hasattr(per, 'can_assign_owner'):
         return per.can_assign_owner(article, user)        
-    except:
-      return False
+    else:
+        return False
 
 def can_change_permissions(article, user):
     if callable(settings.CAN_CHANGE_PERMISSIONS):
         return settings.CAN_CHANGE_PERMISSIONS(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+    elif hasattr(per, 'can_change_permissions'):
         return per.can_change_permissions(article, user)        
-    except:
-      return (
-          not user.is_anonymous() and (
-              article.owner == user or 
-              user.has_perm('wiki.assign')
-          )
-      )
+    else:
+        return (
+            not user.is_anonymous() and (
+                article.owner == user or 
+                user.has_perm('wiki.assign')
+            )
+        )
 
 def can_delete(article, user):
     if callable(settings.CAN_DELETE):
         return settings.CAN_DELETE(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+    elif hasattr(per, 'can_delete'):
         return per.can_delete(article, user)        
-    except:
-      return not user.is_anonymous() and article.can_write(user)
+    else:
+        return not user.is_anonymous() and article.can_write(user)
 
 def can_moderate(article, user):
     if callable(settings.CAN_MODERATE):
         return settings.CAN_MODERATE(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+    elif hasattr(per, 'can_moderate'):
         return per.can_moderate(article, user)        
-    except:
-      return not user.is_anonymous() and user.has_perm('wiki.moderate')
+    else:
+        return not user.is_anonymous() and user.has_perm('wiki.moderate')
 
 def can_admin(article, user):
     if callable(settings.CAN_ADMIN):
         return settings.CAN_ADMIN(article, user)
-    try:       
-        module_name = settings.PERMISSIONS_MODULE
-        m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+    elif hasattr(per, 'can_admin'):
         return per.can_admin(article, user)        
-    except:
-      return not user.is_anonymous() and user.has_perm('wiki.admin')
+    else:
+        return not user.is_anonymous() and user.has_perm('wiki.admin')
 

--- a/wiki/core/permissions.py
+++ b/wiki/core/permissions.py
@@ -1,4 +1,5 @@
 from wiki.conf import settings
+import imp
 
 ###############################
 # ARTICLE PERMISSION HANDLING #

--- a/wiki/core/permissions.py
+++ b/wiki/core/permissions.py
@@ -7,7 +7,14 @@ if settings.PERMISSIONS_MODULE:
     try:
         module_name = settings.PERMISSIONS_MODULE
         m = module_name.split('.')
-        per = imp.load_source(module_name, m[0])
+
+        file, pathname, description = imp.find_module(m[0])       
+        try:
+            per = imp.load_module(module_name, file, pathname, description)
+        finally:
+            # Since we may exit via an exception, close fp explicitly.
+            if file:
+                file.close()
         
         #Helper for app loading order problem.
         if (not hasattr(per, 'can_read') and not hasattr(per, 'can_write') and not hasattr(per, 'can_admin') and


### PR DESCRIPTION
Make custom permissions functions from module instead of simple
callable.
Callable was impractical because of circular imports or module not yet
loaded in settings.

This way define a string with the module to load that overrides the
permission functions. No import problems.

Callables are still working for backward compatibility. 