### PR TITLE
Use lazy translation where needed.

### DIFF
--- a/wiki/core/plugins/base.py
+++ b/wiki/core/plugins/base.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 """Base classes for different plugin objects.
 

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 from django.forms.util import flatatt
 from django.utils.encoding import force_unicode

--- a/wiki/plugins/attachments/forms.py
+++ b/wiki/plugins/attachments/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.plugins.attachments import models
 from wiki.core.permissions import can_moderate

--- a/wiki/plugins/attachments/wiki_plugin.py
+++ b/wiki/plugins/attachments/wiki_plugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import patterns, url, include
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/help/wiki_plugin.py
+++ b/wiki/plugins/help/wiki_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/images/forms.py
+++ b/wiki/plugins/images/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins.base import PluginSidebarFormMixin
 from wiki.plugins.images import models

--- a/wiki/plugins/images/wiki_plugin.py
+++ b/wiki/plugins/images/wiki_plugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import patterns, url
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/links/wiki_plugin.py
+++ b/wiki/plugins/links/wiki_plugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf.urls import patterns, url
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/notifications/forms.py
+++ b/wiki/plugins/notifications/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms.models import modelformset_factory, BaseModelFormSet
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from django_notify.models import Settings, NotificationType
 from django_notify import settings as notify_settings


### PR DESCRIPTION
Use ugettext_lazy for files that use `_()` at module load-time.
