### PR TITLE
replcae ArticleEmptyQuerySet to query_set().none(). Django 1.6 compatibi...

### DIFF
--- a/wiki/managers.py
+++ b/wiki/managers.py
@@ -1,15 +1,9 @@
 from django.db import models
 from django.db.models import Q
 from django.db.models.query import QuerySet, EmptyQuerySet
+
 from mptt.managers import TreeManager
 
-class ArticleEmptyQuerySet(EmptyQuerySet):
-    def can_read(self, user):
-        return self
-    def can_write(self, user):
-        return self
-    def active(self):
-        return self
 
 class ArticleQuerySet(QuerySet):
     
@@ -95,7 +89,7 @@ class ArticleFkEmptyQuerySet(ArticleFkEmptyQuerySetMixin, EmptyQuerySet):
 
 class ArticleManager(models.Manager):
     def get_empty_query_set(self):
-        return ArticleEmptyQuerySet(model=self.model)
+        return self.get_query_set().none()
     def get_query_set(self):
         return ArticleQuerySet(self.model, using=self._db)
     def active(self):

--- a/wiki/tests/__init__.py
+++ b/wiki/tests/__init__.py
@@ -152,3 +152,11 @@ class WebClientTest(TestCase):
         self.assertRedirects(response, reverse('wiki:get', kwargs={'path': 'Test/'}))
         self.assertContains(self.get_by_path('Test/'), 'Other content on level 1')
         self.assertContains(self.get_by_path('Level1/Test/'), 'Content') # on level 2')
+
+    def test_empty_search(self):
+        c = self.c
+        response = c.get(reverse('wiki:search'), {'q': 'Article'})
+        self.assertContains(response, 'Root Article')
+
+        response = c.get(reverse('wiki:search'), {'q': ''})
+        self.assertFalse(response.context['articles'])


### PR DESCRIPTION
Search with empty string results in an error because in django 1.6 EmptyQuerySet.**init** raise error
