### PR TITLE
corrected lists section of help plugin for sub items

### DIFF
--- a/wiki/plugins/help/templates/wiki/plugins/help/sidebar.html
+++ b/wiki/plugins/help/templates/wiki/plugins/help/sidebar.html
@@ -30,8 +30,8 @@ Huger header
 <h4>{% trans "Lists" %}</h4>
 
 <pre>- Unordered List
- - Sub Item 1
- - Sub Item 2</pre>
+    - Sub Item 1
+    - Sub Item 2</pre>
 <pre>1. Ordered
 2. List</pre>
 


### PR DESCRIPTION
Per the Markdown spec, and Python-Markdown's implementation, list sub items seem to require four spaces.  Updated the help plugin to reflect this.

cf. https://pythonhosted.org/Markdown/#differences
