### PR TITLE
Added validation for slugs conflicting with 3rd party URLs

### DIFF
--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -26,9 +26,9 @@ MARKDOWN_KWARGS.update(getattr( django_settings, 'WIKI_MARKDOWN_KWARGS', {} ))
 # and all their content.
 LOST_AND_FOUND_SLUG = getattr( django_settings, 'WIKI_LOST_AND_FOUND_SLUG', 'lost-and-found' )
 
-# When False, this blocks new slugs that resolve to non-wiki views, stopping
+# When True, this blocks new slugs that resolve to non-wiki views, stopping
 # users creating articles that conflict with overlapping URLs from other apps.
-ALLOW_OVERLAPPING_THIRD_PARTY_URL = getattr( django_settings, 'WIKI_ALLOW_OVERLAPPING_THIRD_PARTY_URL', False )
+CHECK_SLUG_URL_AVAILABLE = getattr( django_settings, 'WIKI_CHECK_SLUG_URL_AVAILABLE', True )
 
 # Do we want to log IPs?
 LOG_IPS_ANONYMOUS = getattr( django_settings, 'WIKI_LOG_IPS_ANONYMOUS', True )

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -272,7 +272,7 @@ class CreateForm(forms.Form, SpamProtectionMixin):
             else:
                 raise forms.ValidationError(_('A slug named "%s" already exists.') % already_urlpath.slug)
         
-        if not settings.ALLOW_OVERLAPPING_THIRD_PARTY_URL:
+        if settings.CHECK_SLUG_URL_AVAILABLE:
             try:
                 # Fail validation if URL resolves to non-wiki app
                 match = resolve(self.urlpath_parent.path + '/' + slug + '/')


### PR DESCRIPTION
Added setting, `ALLOW_OVERLAPPING_THIRD_PARTY_URL`, which disables when `True`
