### PR TITLE
Change empty markdown config to {} instead of None

### DIFF
--- a/wiki/plugins/links/mdx/urlize.py
+++ b/wiki/plugins/links/mdx/urlize.py
@@ -97,7 +97,7 @@ class UrlizeExtension(markdown.Extension):
         """ Replace autolink with UrlizePattern """
         md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
 
-def makeExtension(configs=None):
+def makeExtension(configs={}):
     return UrlizeExtension(configs=configs)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Markdown does not accept None as empty configs. See:
https://github.com/waylan/Python-Markdown/issues/357
Thus, the default value for configs keyword argument should be {} instead of None.
