### PR TITLE
Fix Travis CI requirements to use django-mptt==0.6.0

### DIFF
--- a/.travis/requirements.txt
+++ b/.travis/requirements.txt
@@ -10,6 +10,7 @@ django-sekizai>=0.7
 Pillow
 # Notification system
 django-nyt>=0.9.1
-django-mptt>=0.5.5
+# django-mptt 0.6.1 is broken, see #316
+django-mptt==0.6.0
 six
 


### PR DESCRIPTION
django-mptt 0.6.1 is broken, thus force version to 0.6.0 in Travis CI requirements too. This had been done in normal requirements.txt already.

I'm not absolutely sure about this fix, but at least it fixed some of my unit tests and I think it makes sense to use the same requirement as in the normal requirements.txt.
