### PR TITLE
Fix hashbang in testproject/manage.py

### DIFF
--- a/testproject/manage.py
+++ b/testproject/manage.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import unicode_literals
-#!/usr/bin/env python
+
 import os
 import sys
 


### PR DESCRIPTION
testproject/manage.py could not be run as ./manage.py because shebang was not the first line. Thus, the import commands raised errors. Obviously, "python manage.py" worked but now even short "./manage.py" works.
