### PR TITLE
Fix issue #326

### DIFF
--- a/wiki/templatetags/wiki_tags.py
+++ b/wiki/templatetags/wiki_tags.py
@@ -106,11 +106,11 @@ def get_content_snippet(content, keyword, max_words=30):
         html = mark_safe(html)
     else:
         html = " ".join(
-            filter(
+            list(filter(
                 lambda x: x != "",
                 striptags(content).replace(
                     "\n",
-                    " ").split(" "))[
+                    " ").split(" ")))[
                 :max_words])
     return html
 


### PR DESCRIPTION
If the search query hit only the title but not article content, an exception was raised. Convert filter results explicitly from an iterable to a list in order to fix it.
