### PR TITLE
Use lazy translations everywhere

### DIFF
--- a/wiki/core/plugins/base.py
+++ b/wiki/core/plugins/base.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 """Base classes for different plugin objects.
 

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 from django.forms.util import flatatt
 from six.moves import range

--- a/wiki/plugins/attachments/forms.py
+++ b/wiki/plugins/attachments/forms.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.plugins.attachments import models
 from wiki.core.permissions import can_moderate

--- a/wiki/plugins/attachments/views.py
+++ b/wiki/plugins/attachments/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, get_object_or_404
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import TemplateView, View
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView

--- a/wiki/plugins/attachments/wiki_plugin.py
+++ b/wiki/plugins/attachments/wiki_plugin.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django.conf.urls import patterns, url, include
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/help/wiki_plugin.py
+++ b/wiki/plugins/help/wiki_plugin.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/images/forms.py
+++ b/wiki/plugins/images/forms.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins.base import PluginSidebarFormMixin
 from wiki.plugins.images import models

--- a/wiki/plugins/images/views.py
+++ b/wiki/plugins/images/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import RedirectView
 from django.views.generic.list import ListView
 

--- a/wiki/plugins/images/wiki_plugin.py
+++ b/wiki/plugins/images/wiki_plugin.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django.conf.urls import patterns, url
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/links/wiki_plugin.py
+++ b/wiki/plugins/links/wiki_plugin.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 from django.conf.urls import patterns, url
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/macros/mdx/macro.py
+++ b/wiki/plugins/macros/mdx/macro.py
@@ -5,7 +5,7 @@ import markdown
 import re
 from six import string_types
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 from django.template import Context
 

--- a/wiki/plugins/macros/wiki_plugin.py
+++ b/wiki/plugins/macros/wiki_plugin.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/notifications/forms.py
+++ b/wiki/plugins/notifications/forms.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from django import forms
 from django.forms.models import modelformset_factory, BaseModelFormSet
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from django_nyt.models import Settings, NotificationType, Subscription
 from django_nyt import settings as notify_settings

--- a/wiki/plugins/notifications/util.py
+++ b/wiki/plugins/notifications/util.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 def get_title(article):
     """Utility function to format the title of an article..."""

--- a/wiki/plugins/notifications/views.py
+++ b/wiki/plugins/notifications/views.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.edit import FormView
 
 from . import forms

--- a/wiki/views/accounts.py
+++ b/wiki/views/accounts.py
@@ -19,7 +19,7 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect, render_to_response
 from django.template.context import RequestContext
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import View
 from django.views.generic.edit import CreateView, FormView
 

--- a/wiki/views/article.py
+++ b/wiki/views/article.py
@@ -11,7 +11,7 @@ from django.db import transaction
 from django.shortcuts import render_to_response, redirect, get_object_or_404
 from django.template.context import RequestContext
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import TemplateView, View, RedirectView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView


### PR DESCRIPTION
Lazy translations are necessary if the language changes. Otherwise the translator uses the language that was used at the beginning. Now it is possible to switch between languages in the wiki.

I'm not sure if this causes a huge overhead. Or whether in some specific cases it would be ok to use non-lazy translations. But at least this fixed the translation switching for the plugins for me.
