### PR TITLE
Fix issues in macro plugin regex

### DIFF
--- a/wiki/plugins/macros/mdx/macro.py
+++ b/wiki/plugins/macros/mdx/macro.py
@@ -81,9 +81,17 @@ class MacroPreprocessor(markdown.preprocessors.Preprocessor):
                                     value = value.replace("\\", "")
                                     value = value.replace("¤KEEPME¤", "\\")
                             kwargs_dict[str(arg)] = value
-                        new_line += getattr(self, macro)(**kwargs_dict)
+                        try:
+                            new_line += getattr(self, macro)(**kwargs_dict)
+                        except TypeError:
+                            # Catch invalid args
+                            new_line += line[m.start():m.end()]
+                        except ValueError:
+                            # Catch invalid values
+                            new_line += line[m.start():m.end()]
                     else:
                         new_line += getattr(self, macro)()
+                        
             if not line is None:
                 if pos != 0:
                     new_line += line[pos:]


### PR DESCRIPTION
The list of fixes and some examples that work incorrectly in the current regex:
- can have several optional arguments without squashing everything into one argument
  - `[article_list title:"My title" depth:2]`
  - `[article_list depth:2 title:"My title"]`
- the value of an argument can be one word or several words in single or double quotes
  - `[article_list title:"Double quoted title"]`
- macro is matched only if all its optional arguments are valid
  - `[article_list depth: ]`    <-- not valid, should not be matched
- correct handling of ] character in the value of an argument
  - `[article_list depth:2] this is not macro anymore ]`
  - `[article_list title:"Index]"`   <-- this should not be valid macro syntax
- handles whitespace everywhere (if some whitespace is not wanted to be valid, can be modified):
  - `[ article_list]`
  - `[article_list ]`
  - `[article_list depth : 2]`

It is useful to have the pull request https://github.com/django-wiki/django-wiki/pull/334 merged in order to test `title` argument.
