### PR TITLE
Use lazy translations for i18n

### DIFF
--- a/wiki/core/plugins/base.py
+++ b/wiki/core/plugins/base.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 """Base classes for different plugin objects.
 

--- a/wiki/models/urlpath.py
+++ b/wiki/models/urlpath.py
@@ -22,7 +22,7 @@ except:
    notrans=transaction.commit_manually
 
 from django.db.models.signals import post_save, pre_delete
-from django.utils.translation import ugettext_lazy as _, ugettext
+from django.utils.translation import ugettext_lazy as _
 
 from mptt.fields import TreeForeignKey
 from mptt.models import MPTTModel
@@ -161,7 +161,7 @@ class URLPath(MPTTModel):
     
     def __str__(self):
         path = self.path
-        return path if path else ugettext("(root)")
+        return path if path else _("(root)")
     
     def save(self, *args, **kwargs):
         super(URLPath, self).save(*args, **kwargs)

--- a/wiki/plugins/attachments/forms.py
+++ b/wiki/plugins/attachments/forms.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django import forms
-from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
 from wiki.plugins.attachments import models
@@ -102,14 +101,14 @@ class AttachmentArchiveForm(AttachmentForm):
                     except IllegalFileExtension as e:
                         raise forms.ValidationError(e)
             except zipfile.BadZipfile:
-                raise forms.ValidationError(ugettext("Not a zip file"))
+                raise forms.ValidationError(_("Not a zip file"))
         else:
             return super(AttachmentArchiveForm, self).clean_file()
         return uploaded_file
     
     def clean(self):
         if not can_moderate(self.article, self.request.user):
-            raise forms.ValidationError(ugettext("User not allowed to moderate this article"))
+            raise forms.ValidationError(_("User not allowed to moderate this article"))
         return self.cleaned_data
         
     def save(self, *args, **kwargs):
@@ -157,7 +156,7 @@ class DeleteForm(forms.Form):
     
     def clean_confirm(self):
         if not self.cleaned_data['confirm']:
-            raise forms.ValidationError(ugettext('You are not sure enough!'))
+            raise forms.ValidationError(_('You are not sure enough!'))
         return True
 
 class SearchForm(forms.Form):

--- a/wiki/plugins/attachments/markdown_extensions.py
+++ b/wiki/plugins/attachments/markdown_extensions.py
@@ -8,6 +8,8 @@ from django.template.context import Context
 from django.template.loader import render_to_string
 from django.contrib.auth.models import AnonymousUser
 from wiki.core.permissions import can_read
+from django.utils.translation import ugettext_lazy as _
+
 
 ATTACHMENT_RE = re.compile(r'(?P<before>.*)(\[attachment\:(?P<id>\d+)\])(?P<after>.*)', re.IGNORECASE)
 
@@ -60,7 +62,9 @@ class AttachmentPreprocessor(markdown.preprocessors.Preprocessor):
                         }))
                     line = self.markdown.htmlStash.store(html, safe=True)
                 except models.Attachment.DoesNotExist:
-                    html = """<span class="attachment attachment-deleted">Attachment with ID #%s is deleted.</span>""" % attachment_id
+                    html = """<span class="attachment attachment-deleted">{text}</span>""".format(
+                        text=_("Attachment with ID #{id_number} is deleted.").format(id_number=attachment_id)
+                    )
                     line = line.replace(m.group(2), self.markdown.htmlStash.store(html, safe=True))
                 line = before + line + after
             new_text.append(line)

--- a/wiki/plugins/attachments/models.py
+++ b/wiki/plugins/attachments/models.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import os.path
 
 from django.db import models
-from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings as django_settings
@@ -60,9 +59,9 @@ def extension_allowed(filename):
         extension = filename.split(".")[-1]
     except IndexError:
         # No extension
-        raise IllegalFileExtension(ugettext("No file extension found in filename. That's not okay!"))
+        raise IllegalFileExtension(_("No file extension found in filename. That's not okay!"))
     if not extension.lower() in map(lambda x: x.lower(), settings.FILE_EXTENSIONS):
-        raise IllegalFileExtension(ugettext("The following filename is illegal: %s. Extension has to be one of %s") % 
+        raise IllegalFileExtension(_("The following filename is illegal: %s. Extension has to be one of %s") % 
                                    (filename, ", ".join(settings.FILE_EXTENSIONS)))
     
     return extension

--- a/wiki/plugins/attachments/views.py
+++ b/wiki/plugins/attachments/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, get_object_or_404
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import TemplateView, View
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView

--- a/wiki/plugins/attachments/wiki_plugin.py
+++ b/wiki/plugins/attachments/wiki_plugin.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django.conf.urls import patterns, url, include
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/help/wiki_plugin.py
+++ b/wiki/plugins/help/wiki_plugin.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/images/forms.py
+++ b/wiki/plugins/images/forms.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django import forms
-from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins.base import PluginSidebarFormMixin
@@ -17,7 +16,9 @@ class SidebarForm(PluginSidebarFormMixin):
         self.fields['image'].required = True
     
     def get_usermessage(self):
-        return ugettext("New image %s was successfully uploaded. You can use it by selecting it from the list of available images.") % self.instance.get_filename()
+        return _("New image {image_name} was successfully uploaded. You can use it by selecting it from the list of available images.").format(
+            image_name=self.instance.get_filename()
+        )
     
     def save(self, *args, **kwargs):
         if not self.instance.id:
@@ -66,5 +67,5 @@ class PurgeForm(forms.Form):
     def clean_confirm(self):
         confirm = self.cleaned_data['confirm']
         if not confirm:
-            raise forms.ValidationError(ugettext('You are not sure enough!'))
+            raise forms.ValidationError(_('You are not sure enough!'))
         return confirm

--- a/wiki/plugins/images/views.py
+++ b/wiki/plugins/images/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import RedirectView
 from django.views.generic.list import ListView
 

--- a/wiki/plugins/images/wiki_plugin.py
+++ b/wiki/plugins/images/wiki_plugin.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django.conf.urls import patterns, url
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/links/wiki_plugin.py
+++ b/wiki/plugins/links/wiki_plugin.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 # -*- coding: utf-8 -*-
 from django.conf.urls import patterns, url
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/wiki/plugins/notifications/forms.py
+++ b/wiki/plugins/notifications/forms.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from django import forms
 from django.forms.models import modelformset_factory, BaseModelFormSet
-from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
 from django_nyt.models import Settings, NotificationType, Subscription
@@ -17,7 +16,7 @@ from wiki.plugins.notifications import models
 
 class SettingsModelChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
-        return ugettext(
+        return _(
             "Receive notifications %(interval)s"
         ) % {
             'interval': obj.get_interval_display()
@@ -27,7 +26,7 @@ class SettingsModelChoiceField(forms.ModelChoiceField):
 
 class ArticleSubscriptionModelMultipleChoiceField(forms.ModelMultipleChoiceField):
     def label_from_instance(self, obj):
-        return ugettext("%(title)s - %(url)s") % {
+        return _("%(title)s - %(url)s") % {
             'title': obj.article.current_revision.title,
             'url': obj.article.get_absolute_url()
         }
@@ -42,17 +41,17 @@ class SettingsModelForm(forms.ModelForm):
             self.__editing_instance = True
             self.fields['delete_subscriptions'] = ArticleSubscriptionModelMultipleChoiceField(
                 models.ArticleSubscription.objects.filter(subscription__settings=instance),
-                label=ugettext("Remove subscriptions"),
+                label=_("Remove subscriptions"),
                 required=False,
-                help_text=ugettext("Select article subscriptions to remove from notifications"),
+                help_text=_("Select article subscriptions to remove from notifications"),
                 initial = models.ArticleSubscription.objects.none(),
             )
             self.fields['email'] = forms.TypedChoiceField(
                 label=_("Email digests"),
                 choices = (
-                    (0, ugettext('Unchanged (selected on each article)')),
-                    (1, ugettext('No emails')),
-                    (2, ugettext('Email on any change')),
+                    (0, _('Unchanged (selected on each article)')),
+                    (1, _('No emails')),
+                    (2, _('Email on any change')),
                 ),
                 coerce=lambda x: int(x) if not x is None else None,
                 widget=forms.RadioSelect(),

--- a/wiki/templates/wiki/includes/revision_info.html
+++ b/wiki/templates/wiki/includes/revision_info.html
@@ -7,7 +7,7 @@
 
 
 {% load wiki_tags i18n %}
-{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user %}{{ revision.ip_address|default:"anonymous (IP not logged)" }}{% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
+{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user %}{{ revision.ip_address|default:_("anonymous (IP not logged)") }}{% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
 {% if revision == current_revision %}
   <strong>*</strong>
 {% endif %}

--- a/wiki/views/accounts.py
+++ b/wiki/views/accounts.py
@@ -19,7 +19,8 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect, render_to_response
 from django.template.context import RequestContext
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
+
 from django.views.generic.base import View
 from django.views.generic.edit import CreateView, FormView
 

--- a/wiki/views/article.py
+++ b/wiki/views/article.py
@@ -11,7 +11,7 @@ from django.db import transaction
 from django.shortcuts import render_to_response, redirect, get_object_or_404
 from django.template.context import RequestContext
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import TemplateView, View, RedirectView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView


### PR DESCRIPTION
In our project (edx/edx-platform), we need ALL the translations to be lazy for full i18n of django-wiki to work and be presented properly to logged in users.

The problem is that with ugettext, strings are translated during import. That's too soon, so the user's language isn't taken into account. ugettext_lazy will produce an object at import time that will be actually translated when the string is needed, which is later, when the user's language is known.

This seems to me like something that upstream should have. It can only be more correct to use ugettext_lazy than ugettext.
