### PR TITLE
Properly synchronised tox and travis test config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,16 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-# Python 3.2 support removed as South migrations wont run
-#  - "3.2"
-  - "3.3"
+# See tox.ini for env list
 env:
-# Django 1.4 support is dumped because of introduction of python3 support
-#    - DJANGO="Django>=1.4,<1.5"
-    - DJANGO="Django>=1.5,<1.6"
-    - DJANGO="Django>=1.6,<1.7"
-#    - DJANGO="Django>=1.7,<1.8"
+- TOXENV=py26-django15
+- TOXENV=py26-django16
+- TOXENV=py27-django15
+- TOXENV=py27-django16
+- TOXENV=py33-django15
+- TOXENV=py33-django16
 install:
-  - pip install $DJANGO -r requirements.txt
-matrix:
-    exclude:
-        # Invalid example left to fill in the exclude block.
-        - python: "2.0"
-          env: DJANGO="Django>=2000.0"
-        # Python 3.2, migrations are broken with South so we should take care not to include
-        # it when adding 1.7 support
-        #- python: "3.2"
-        #  env: DJANGO="Django>=1.7"
-# command to run tests
+- pip install tox
 script:
-  - cd testproject ; python -W error:"":"":0 manage.py test wiki --settings=testproject.settings.travis --traceback
+- tox
 notifications:
     irc:
         - "irc.freenode.org#django-wiki"

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,7 +2,6 @@ include COPYING
 include README.md
 include README.rst
 include setup.cfg
-include requirements.txt
 include model_chart_wiki.pdf
 recursive-include wiki *.html *.txt *.png *.js *.css *.gif *.less *.mo *.po *.otf *.svg *.woff *.eot *.ttf
 prune wiki/attachments

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ So far the dependencies/requirements are:
 Development
 ------------
 
-In your Git fork, run `pip install -r requirements.txt` to install the requirements.
+In your Git fork, run `setup.py develop` to install the requirements.
 
 The folder **testproject/** contains a pre-configured django project and an sqlite database. Login for django admin is *admin:admin*. This project should always be maintained, but please do not commit changes to the SQLite database as we only care about its contents in case data models are changed.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-# For general guidance on setup.py vs requirements.txt, see:
-# https://caremad.io/blog/setup-vs-requirement/
-
-# You can add installation specific requirements here
-# ...
-
-# Install requirements from setup.py (and install the local package)
--e .

--- a/runtests.py
+++ b/runtests.py
@@ -15,7 +15,7 @@ settings.configure(
     },
     SITE_ID=1,
     ROOT_URLCONF='wiki.tests.testdata.urls',
-    INSTALLED_APPS=(
+    INSTALLED_APPS=[
         'wiki.tests.testdata',
         'django.contrib.auth',
         'django.contrib.contenttypes',
@@ -33,7 +33,7 @@ settings.configure(
         'wiki.plugins.notifications',
         'wiki.plugins.images',
         'wiki.plugins.macros',
-    ),
+    ],
     TEMPLATE_CONTEXT_PROCESSORS=(
         "django.contrib.auth.context_processors.auth",
         "django.core.context_processors.debug",
@@ -47,8 +47,8 @@ settings.configure(
     ),
     USE_TZ=True,
     SOUTH_TESTS_MIGRATE=True,
+    SECRET_KEY = 'b^fv_)t39h%9p40)fnkfblo##jkr!$0)lkp6bpy!fi*f$4*92!',
 )
-
 
 # If you use South for migrations, uncomment this to monkeypatch
 # syncdb to get migrations to run.
@@ -56,7 +56,7 @@ from south.management.commands import patch_for_test_db_setup
 patch_for_test_db_setup()
 
 from django.core.management import execute_from_command_line
-argv = [sys.argv[0], "test"]
+argv = [sys.argv[0], "test", "--traceback"]
 
 if len(sys.argv) == 1:
     # Nothing following 'runtests.py':

--- a/testproject/testproject/settings/travis.py
+++ b/testproject/testproject/settings/travis.py
@@ -1,5 +1,0 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from testproject.settings import *
-
-SECRET_KEY = 'b^fv_)t39h%9p40)fnkfblo##jkr!$0)lkp6bpy!fi*f$4*92!'

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27-django14, py27-django15, py27-django16, py33-django16
+# Ensure you add to .travis.yml if you add here
+envlist = py26-django15, py26-django16, py27-django15, py27-django16, py33-django15, py33-django16
 
 [testenv]
-commands = ./runtests.py
+commands = python -W all:"":"":"":0 runtests.py
 deps =
      Markdown==2.3.1
      Pillow==2.3.0
@@ -14,10 +15,16 @@ deps =
      six==1.6.1
      django_nyt==0.9.4
 
-[testenv:py27-django14]
-basepython = python2.7
+[testenv:py26-django15]
+basepython = python2.6
 deps =
-     Django==1.4.15
+     Django==1.5.10
+     {[testenv]deps}
+
+[testenv:py26-django16]
+basepython = python2.6
+deps =
+     Django==1.6.8
      {[testenv]deps}
 
 [testenv:py27-django15]
@@ -29,11 +36,17 @@ deps =
 [testenv:py27-django16]
 basepython = python2.7
 deps =
-     Django==1.6.7
+     Django==1.6.8
+     {[testenv]deps}
+
+[testenv:py33-django15]
+basepython = python3.3
+deps =
+     Django==1.5.10
      {[testenv]deps}
 
 [testenv:py33-django16]
 basepython = python3.3
 deps =
-     Django==1.6.7
+     Django==1.6.8
      {[testenv]deps}


### PR DESCRIPTION
This is a new PR that supersedes my old one. I also have Django 1.7 fixes and others, which I'll send in a separate PR. This hopefully is a close replacement for the .travis.yml config.

This does a number of things:
- Fixes tox.ini to not run Django 1.4 tests (as its not supported any more)
- Fixes tox.ini to run Python 3.3 tests and Python 2.6
- Use "./runtests.py" for running travis tests, not something different,
  so everything is consistent. One Way To Do It.
- Removes requirements.txt, as this is confusing and not needed
  (you can use "setup.py develop" for installing in development)

This fixes several bugs with Travis tests:
- They ran against different (and underspecified) versions of packages from tox.ini
- They didn't run tests fully - Travis didn't run the attachments tests on
  Django < 1.6.  This is the kind of thing that is easily overlooked if
  you've got multiple ways to run tests.
