### PR TITLE
Properly sets default configs in plugins/links/mdx

### DIFF
--- a/wiki/plugins/links/mdx/urlize.py
+++ b/wiki/plugins/links/mdx/urlize.py
@@ -98,7 +98,8 @@ class UrlizeExtension(markdown.Extension):
         """ Replace autolink with UrlizePattern """
         md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
 
-def makeExtension(configs={}):
+def makeExtension(configs=None):
+    if configs is None: configs = {}
     return UrlizeExtension(configs=configs)
 
 if __name__ == "__main__":


### PR DESCRIPTION
See: http://pythonconquerstheuniverse.wordpress.com/2012/02/15/mutable-default-arguments/

Worth a test case?