### PR TITLE
Use content_type instead of mimetype

### DIFF
--- a/wiki/core/http.py
+++ b/wiki/core/http.py
@@ -30,7 +30,7 @@ def send_file(request, filepath, last_modified=None, filename=None):
     if settings.USE_SENDFILE:
         response = django_sendfile_response(request, filepath)
     else:
-        response = HttpResponse(open(fullpath, 'rb').read(), mimetype=mimetype)
+        response = HttpResponse(open(fullpath, 'rb').read(), content_type=mimetype)
 
     if not last_modified:
         response["Last-Modified"] = http_date(statobj.st_mtime)

--- a/wiki/decorators.py
+++ b/wiki/decorators.py
@@ -31,7 +31,7 @@ def json_view(func):
                 return obj
         data = json.dumps(obj, ensure_ascii=False)
         status = kwargs.get('status', 200)
-        response = HttpResponse(mimetype='application/json', status=status)
+        response = HttpResponse(content_type='application/json', status=status)
         response.write(data)
         return response
     return wrap


### PR DESCRIPTION
Mimetype was completely removed in Django 1.7