### PR TITLE
Additional block for overriding branding in page title

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -14,18 +14,22 @@ turn simply inherits from ``wiki/base_site.html`` (adding
 nothing). ``wiki/base_site.html`` provides a complete HTML page, but provides a
 number of blocks that you might want to override. The most useful are:
 
+* ``wiki_site_title``
 * ``wiki_header_branding``
 * ``wiki_header_navlinks``
 
 These can be overridden to provide your own branding and links in the top bar of
-the page. The ``wiki/base_site.html`` template uses Bootstrap 3, so the
-following example shows how to use this in practice, assuming you want a single
-link to your home page, and one to the wiki. Add the following as
-``wiki/base.html`` somewhere in your ``TEMPLATE_DIRS``:
+the page, as well as in browser window title. The ``wiki/base_site.html``
+template uses Bootstrap 3, so the following example shows how to use this in
+practice, assuming you want a single link to your home page, and one to the
+wiki. Add the following as ``wiki/base.html`` somewhere in your
+``TEMPLATE_DIRS``:
 
 .. code-block:: html+django
 
    {% extends "wiki/base_site.html" %}
+
+   {% block wiki_site_title %} - Wiki{% endblock %}
 
    {% block wiki_header_branding %}
    <a class="navbar-brand" href="/">Your brand</a>

--- a/wiki/templates/wiki/base_site.html
+++ b/wiki/templates/wiki/base_site.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{% block wiki_pagetitle %}{% endblock %} - django-\/\/  i K |</title>
+    <title>{% block wiki_pagetitle %}{% endblock %}{% block wiki_site_title %} - django-\/\/  i K |{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="">


### PR DESCRIPTION
Added additional block to base template that allows overriding the site title (within <title> tag). Implements #387.

It's a fairly simple patch, although I'm not sure if it would be better to allow people to be able to override the entire <title> tag in one go. I'm assuming that most people won't want to do that, though, and just want to change the branding part.