### PR TITLE
Hide article menu labels in mobile view

### DIFF
--- a/wiki/templates/wiki/includes/article_menu.html
+++ b/wiki/templates/wiki/includes/article_menu.html
@@ -6,7 +6,7 @@
   {% if not user.is_anonymous %}
   <a href="{% url 'wiki:settings' article_id=article.id path=urlpath.path %}">
     <span class="fa fa-wrench"></span>
-    {% trans "Settings" %}
+    <span class="hidden-xs">{% trans "Settings" %}</span>
   </a>
   {% endif %}
 </li>
@@ -15,7 +15,7 @@
   <li class="pull-right{% if selected == plugin.slug %} active{% endif %}">
     <a href="{% url 'wiki:plugin' slug=plugin.slug article_id=article.id path=urlpath.path %}">
       <span class="{{ plugin.article_tab.1 }}"></span>
-      {{ plugin.article_tab.0 }}
+      <span class="hidden-xs">{{ plugin.article_tab.0 }}</span>
     </a>
   </li>
 {% endfor %}
@@ -23,7 +23,7 @@
 <li class="pull-right{% if selected == "history" %} active{% endif %}">
   <a href="{% url 'wiki:history' article_id=article.id path=urlpath.path %}">
     <span class="fa fa-clock-o"></span>
-    {% trans "Changes" %}
+    <span class="hidden-xs">{% trans "Changes" %}</span>
   </a>
 </li>
 
@@ -31,14 +31,14 @@
 <li class="pull-right{% if selected == "edit" %} active{% endif %}">
   <a href="{% url 'wiki:edit' article_id=article.id path=urlpath.path %}">
     <span class="fa fa-edit"></span>
-    {% trans "Edit" %}
+    <span class="hidden-xs">{% trans "Edit" %}</span>
   </a>
 </li>
 {% else %}
 <li class="pull-right{% if selected == "source" %} active{% endif %}">
   <a href="{% url 'wiki:source' article_id=article.id path=urlpath.path %}">
     <span class="fa fa-lock"></span>
-    {% trans "View Source" %}
+    <span class="hidden-xs">{% trans "View Source" %}</span>
   </a>
 </li>
 {% endif %}
@@ -46,7 +46,7 @@
 <li class="pull-right{% if selected == "view" %} active{% endif %}">
   <a href="{% url 'wiki:get' article_id=article.id path=urlpath.path %}">
     <span class="fa fa-home"></span>
-    {% trans "View" %}
+    <span class="hidden-xs">{% trans "View" %}</span>
   </a>
 </li>
 


### PR DESCRIPTION
Before:

![](http://i.imgur.com/2IlGA0x.png)

After: 

![](http://i.imgur.com/iodZpLh.png)

Looks the same for any size bigger than xs. 