### PR TITLE
Fixed the compatible with the `USERNAME_FIELD` for the Django version below 1.5.

### DIFF
--- a/wiki/core/compat.py
+++ b/wiki/core/compat.py
@@ -21,6 +21,8 @@ def get_user_model():
         return gum()
     else:
         from django.contrib.auth.models import User
+        if 'USERNAME_FIELD' not in User.__dict__:
+            User.USERNAME_FIELD = 'username'
         return User
 
 


### PR DESCRIPTION
The `User` model without `USERNAME_FIELD` attribute might get error in `PermissionsForm`.