### PR TITLE
Import all models in models/__init__.py (fixes #399)

### DIFF
--- a/wiki/models/__init__.py
+++ b/wiki/models/__init__.py
@@ -10,6 +10,7 @@ from six import string_types
 
 # TODO: Don't use wildcards
 from .article import *
+from .pluginbase import *
 from .urlpath import *
 
 # TODO: Should the below stuff be executed a more logical place?


### PR DESCRIPTION
Without this import statement, `manage.py makemigrations` creates a new migration to delete all the plugin base models, because it cannot find them (see #399).