### PR TITLE
Django 15 fixes

### DIFF
--- a/wiki/managers.py
+++ b/wiki/managers.py
@@ -10,6 +10,20 @@ from django import VERSION as DJANGO_VERSION
 from mptt.managers import TreeManager
 
 
+if django.VERSION >= (1, 6):
+    # TreeManager bug:
+    if 'get_query_set' in TreeManager.__dict__:
+        # TreeManager should not define this, it messes things up.
+        del TreeManager.get_query_set
+
+        # See also:
+        # https://github.com/django-mptt/django-mptt/pull/388
+
+        # Once this has been merged, a new release for django-mptt has been
+        # made, and we can specify the new version in our requirements, this
+        # hack can be removed.
+
+
 class QuerySetCompatMixin(object):
 
     def get_queryset_compat(self):

--- a/wiki/managers.py
+++ b/wiki/managers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import django
 from django.db import models
 from django.db.models import Q
 from django.db.models.query import QuerySet, EmptyQuerySet
@@ -12,9 +13,9 @@ from mptt.managers import TreeManager
 class QuerySetCompatMixin(object):
 
     def get_queryset_compat(self):
-        get_queryset = (self.get_queryset
-                        if hasattr(self, 'get_queryset')
-                        else self.get_query_set)
+        get_queryset = (self.get_query_set
+                        if hasattr(self, 'get_query_set')
+                        else self.get_queryset)
         return get_queryset()
 
 
@@ -144,7 +145,8 @@ class ArticleManager(QuerySetCompatMixin, models.Manager):
     def can_write(self, user):
         return self.get_queryset_compat().can_write(user)
 
-    get_query_set = get_queryset  # Django 1.5 compat
+    if django.VERSION < (1, 6):
+        get_query_set = get_queryset
 
 
 class ArticleFkManager(QuerySetCompatMixin, models.Manager):
@@ -162,7 +164,8 @@ class ArticleFkManager(QuerySetCompatMixin, models.Manager):
     def get_queryset(self):
         return ArticleFkQuerySet(self.model, using=self._db)
 
-    get_query_set = get_queryset  # Django 1.5 compat
+    if django.VERSION < (1, 6):
+        get_query_set = get_queryset
 
     def active(self):
         return self.get_queryset_compat().active()
@@ -212,7 +215,8 @@ class URLPathManager(QuerySetCompatMixin, TreeManager):
         return URLPathQuerySet(self.model, using=self._db).order_by(
             self.tree_id_attr, self.left_attr)
 
-    get_query_set = get_queryset  # Django 1.5 compat
+    if django.VERSION < (1, 6):
+        get_query_set = get_queryset
 
     def select_related_common(self):
         return self.get_queryset_compat().common_select_related()

--- a/wiki/tests/__init__.py
+++ b/wiki/tests/__init__.py
@@ -5,3 +5,9 @@ if django.VERSION < (1, 6):
     # New style autodiscovery of tests doesn't work for Django < 1.6,
     # and we don't want to duplicate tests for Django >= 1.6
     from .test_basic import *
+    from .test_managers import *
+    from .test_models import *
+    from .test_template_filters import *
+    from .test_template_tags import *
+    from .test_views import *
+    from .test_urls import *

--- a/wiki/tests/test_managers.py
+++ b/wiki/tests/test_managers.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from .base import ArticleTestBase
 
-from wiki.models import Article
+from wiki.models import Article, URLPath
 from wiki.plugins.attachments.models import Attachment
 
 
@@ -83,3 +83,10 @@ class AttachmentManagerTests(ArticleTestBase):
             Attachment.objects.none().can_write(self.superuser1).count(), 0
         )
         self.assertEqual(Attachment.objects.none().active().count(), 0)
+
+
+class URLPathManagerTests(ArticleTestBase):
+
+    def test_related_manager_works_with_filters(self):
+        root = URLPath.root()
+        self.assertNotIn(root.id, [p.id for p in root.children.active()])

--- a/wiki/tests/test_template_filters.py
+++ b/wiki/tests/test_template_filters.py
@@ -145,12 +145,12 @@ class GetContentSnippet(TemplateTestCase):
 
         content = """
         <h1>Some dummy</h1> text. <div>Actually</div> I don't what to write,
-        heh. Don't now, <b>maybe</b> I should citate <>Shakespeare<> or Byron.
+        heh. Don't now, <b>maybe</b> I should citate Shakespeare or Byron.
         Or <a>maybe</a> copy paste from <a href="http://python.org">python</a>
         or django documentation. Maybe.
         """
 
-        expected = ('I should citate <>Shakespeare<> or Byron. '
+        expected = ('I should citate Shakespeare or Byron. '
             'Or <strong>maybe</strong> copy paste from python '
             'or django documentation. <strong>maybe</strong> .')
 


### PR DESCRIPTION
OK, apologies in advance for a long tale...

First, I noticed that on Django 1.5 only 2 tests were running instead of 65. You can see this here:
https://travis-ci.org/django-wiki/django-wiki/jobs/66873647 (Django 1.5)
https://travis-ci.org/django-wiki/django-wiki/jobs/66873648 (Django 1.6)

The first commit fixes that.

Once the tests are running, there are test failures:
* one fairly straightforward one about striptags. This is fixed in the second changeset
* one nightmare causing an infinite recursion, and potential data loss bugs, due to `get_query_set` chaos.

This is addressed in the third changeset. Fixing it is tricky, but the pattern to use is given in the Django 1.6 release notes. https://docs.djangoproject.com/en/1.8/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset . 

There are other subtleties/chaos, as detailed here: http://lukeplant.me.uk/blog/posts/handling-django%27s-get_query_set-rename-is-hard/ (see bottom for recent update). This caused a failure on Django 1.8! But this is due to `TreeManager` from `django-mptt` not following the right pattern.

I have submitted a pull request to fix `django-mptt`: https://github.com/django-mptt/django-mptt/pull/388

Until that lands and is usable, however, I've fixed the error by using a monkey patch, which is the final changeset.

I've put some of these comments in the individual commit messages, but thought the overall picture might be helpful too.