### PR TITLE
Attachment upload tweak

### DIFF
--- a/wiki/plugins/attachments/tests/test_views.py
+++ b/wiki/plugins/attachments/tests/test_views.py
@@ -53,7 +53,7 @@ class AttachmentTests(ArticleTestBase):
         # Check the object was created.
         attachment = self.article.shared_plugins_set.all()[0].attachment
         self.assertEqual(attachment.original_filename, 'test.txt')
-        self.assertEqual(attachment.current_revision.file.file.read(), data)
+        self.assertEqual(attachment.current_revision.file.file.read(), data.encode('utf-8'))
 
     def test_replace(self):
         """
@@ -86,7 +86,7 @@ class AttachmentTests(ArticleTestBase):
         # Original filenames should not be modified
         self.assertEqual(attachment.original_filename, 'test.txt')
         # Latest revision should equal replacment_data 
-        self.assertEqual(attachment.current_revision.file.file.read(), replacement_data)
+        self.assertEqual(attachment.current_revision.file.file.read(), replacement_data.encode('utf-8'))
         first_replacement = attachment.current_revision 
 
         # Upload another replacement, this time removing most recent revision
@@ -98,6 +98,6 @@ class AttachmentTests(ArticleTestBase):
         # Revision count should still be two 
         self.assertEqual(attachment.attachmentrevision_set.count(), 2)
         # Latest revision should equal replacment_data2
-        self.assertEqual(attachment.current_revision.file.file.read(), replacement_data2)
+        self.assertEqual(attachment.current_revision.file.file.read(), replacement_data2.encode('utf-8'))
         # The first replacement should no longer be in the filehistory
         self.assertNotIn(first_replacement, attachment.attachmentrevision_set.all())

--- a/wiki/plugins/attachments/tests/test_views.py
+++ b/wiki/plugins/attachments/tests/test_views.py
@@ -42,7 +42,7 @@ class AttachmentTests(ArticleTestBase):
         Uploading should not modify file in any way.
         """
         url = reverse('wiki:attachments_index', kwargs={'path': ''})
-        data = "This is a plain text file".encode('utf-8')
+        data = "This is a plain text file"
         filestream = self._createTxtFilestream(data)
         response = self.c.post(url,
                                {'description': 'My file',
@@ -63,7 +63,7 @@ class AttachmentTests(ArticleTestBase):
         """
         # Upload initial file
         url = reverse('wiki:attachments_index', kwargs={'path': ''})
-        data = "This is a plain text file".encode('utf-8')
+        data = "This is a plain text file"
         filestream = self._createTxtFilestream(data)
         self.c.post(url, {'description': 'My file', 'file': filestream, 'save': '1',})
         attachment = self.article.shared_plugins_set.all()[0].attachment 
@@ -76,7 +76,7 @@ class AttachmentTests(ArticleTestBase):
             kwargs={'attachment_id': attachment.id, 'article_id' : self.article.id}) 
 
         # Upload replacement without removing revisions
-        replacement_data = data + ' And this is my edit'.encode('utf-8')
+        replacement_data = data + ' And this is my edit'
         replacement_filestream = self._createTxtFilestream(replacement_data)
         response = self.c.post(url, {'description' : 'Replacement upload', 
                                         'file' : replacement_filestream,})
@@ -90,7 +90,7 @@ class AttachmentTests(ArticleTestBase):
         first_replacement = attachment.current_revision 
 
         # Upload another replacement, this time removing most recent revision
-        replacement_data2 = data + ' And this is a different edit'.encode('utf-8')
+        replacement_data2 = data + ' And this is a different edit'
         replacement_filestream2 = self._createTxtFilestream(replacement_data2)
         response = self.c.post(url, {'description' : 'Replacement upload', 
                                         'file' : replacement_filestream2, 'replace' : 'on',})

--- a/wiki/plugins/attachments/tests/test_views.py
+++ b/wiki/plugins/attachments/tests/test_views.py
@@ -10,18 +10,40 @@ from wiki.tests.base import ArticleTestBase
 
 class AttachmentTests(ArticleTestBase):
 
-    def test_upload(self):
-        data = "This is a plain text file".encode('utf-8')
+    def setUp(self):
+        super(AttachmentTests, self).setUp()
+        self.article = self.root_article
+
+    def _createTxtFilestream(self, strData, **kwargs):
+        """
+        Helper function to create filestream for upload.
+
+        Parameters : 
+        strData : str, test string data
+
+        Optional Arguments : 
+        filename : str, Defaults to 'test.txt'
+        """
+        filename = kwargs.get('filename', 'test.txt')
+        data = strData.encode('utf-8')
         filedata = BytesIO(data)
-        filestream = InMemoryUploadedFile(
-            filedata,
+        filestream = InMemoryUploadedFile(filedata,
             None,
-            'test.txt',
+            filename,
             'text',
             len(data),
             None)
-        article = self.root_article
+        return filestream 
+
+    def test_upload(self):
+        """
+        Tests that simple file upload uploads correctly
+        Uploading a file should preserve the original filename.
+        Uploading should not modify file in any way.
+        """
         url = reverse('wiki:attachments_index', kwargs={'path': ''})
+        data = "This is a plain text file".encode('utf-8')
+        filestream = self._createTxtFilestream(data)
         response = self.c.post(url,
                                {'description': 'My file',
                                 'file': filestream,
@@ -29,7 +51,53 @@ class AttachmentTests(ArticleTestBase):
                                 })
         self.assertRedirects(response, url)
         # Check the object was created.
-        attachment = article.shared_plugins_set.all()[0].attachment
+        attachment = self.article.shared_plugins_set.all()[0].attachment
         self.assertEqual(attachment.original_filename, 'test.txt')
-        self.assertEqual(attachment.current_revision.file.file.read(),
-                         data)
+        self.assertEqual(attachment.current_revision.file.file.read(), data)
+
+    def test_replace(self):
+        """
+        Tests that previous revisions are not deleted
+        Tests that only the most recent revision is deleted when
+        "replace" is checked.
+        """
+        # Upload initial file
+        url = reverse('wiki:attachments_index', kwargs={'path': ''})
+        data = "This is a plain text file".encode('utf-8')
+        filestream = self._createTxtFilestream(data)
+        self.c.post(url, {'description': 'My file', 'file': filestream, 'save': '1',})
+        attachment = self.article.shared_plugins_set.all()[0].attachment 
+
+        # uploading for the first time should mean that there is only one revision.
+        self.assertEqual(attachment.attachmentrevision_set.count(), 1)
+
+        # Change url to replacement page.
+        url = reverse('wiki:attachments_replace', 
+            kwargs={'attachment_id': attachment.id, 'article_id' : self.article.id}) 
+
+        # Upload replacement without removing revisions
+        replacement_data = data + ' And this is my edit'.encode('utf-8')
+        replacement_filestream = self._createTxtFilestream(replacement_data)
+        response = self.c.post(url, {'description' : 'Replacement upload', 
+                                        'file' : replacement_filestream,})
+        attachment = self.article.shared_plugins_set.all()[0].attachment 
+        # Revision count should be two 
+        self.assertEqual(attachment.attachmentrevision_set.count(), 2)
+        # Original filenames should not be modified
+        self.assertEqual(attachment.original_filename, 'test.txt')
+        # Latest revision should equal replacment_data 
+        self.assertEqual(attachment.current_revision.file.file.read(), replacement_data)
+        first_replacement = attachment.current_revision 
+
+        # Upload another replacement, this time removing most recent revision
+        replacement_data2 = data + ' And this is a different edit'.encode('utf-8')
+        replacement_filestream2 = self._createTxtFilestream(replacement_data2)
+        response = self.c.post(url, {'description' : 'Replacement upload', 
+                                        'file' : replacement_filestream2, 'replace' : 'on',})
+        attachment = self.article.shared_plugins_set.all()[0].attachment 
+        # Revision count should still be two 
+        self.assertEqual(attachment.attachmentrevision_set.count(), 2)
+        # Latest revision should equal replacment_data2
+        self.assertEqual(attachment.current_revision.file.file.read(), replacement_data2)
+        # The first replacement should no longer be in the filehistory
+        self.assertNotIn(first_replacement, attachment.attachmentrevision_set.all())

--- a/wiki/plugins/attachments/views.py
+++ b/wiki/plugins/attachments/views.py
@@ -195,9 +195,10 @@ class AttachmentReplaceView(ArticleMixin, FormView):
                         created__lte=attachment_revision.created).latest()
                     most_recent_revision.delete()
                 except ObjectDoesNotExist:
-                    msg = "The file {attachment} does not contain any revisions.".format(attachment=self.attachment)
+                    msg = "{attachment} does not contain any revisions.".format(\
+                        attachment=str(self.attachment.original_filename))
                     messages.error(self.request, msg)
-                    
+
         return redirect(
             "wiki:attachments_index",
             path=self.urlpath.path,

--- a/wiki/plugins/attachments/views.py
+++ b/wiki/plugins/attachments/views.py
@@ -186,12 +186,14 @@ class AttachmentReplaceView(ArticleMixin, FormView):
                 path=self.urlpath.path,
                 article_id=self.article.id)
 
-        if self.can_moderate and form.cleaned_data['replace']:
-            most_recent_revision = self.attachment.attachmentrevision_set.exclude(
-                id=attachment_revision.id,
-                created__lte=attachment_revision.created,
-            ).latest()
-            most_recent_revision.delete()
+        if self.can_moderate:
+            if form.cleaned_data['replace']:
+                # form has no cleaned_data field unless self.can_moderate is True
+                most_recent_revision = self.attachment.attachmentrevision_set.exclude(
+                    id=attachment_revision.id,
+                    created__lte=attachment_revision.created,
+                ).latest()
+                most_recent_revision.delete()
 
         return redirect(
             "wiki:attachments_index",

--- a/wiki/plugins/attachments/views.py
+++ b/wiki/plugins/attachments/views.py
@@ -186,13 +186,12 @@ class AttachmentReplaceView(ArticleMixin, FormView):
                 path=self.urlpath.path,
                 article_id=self.article.id)
 
-        if self.can_moderate:
-            older_revisions = self.attachment.attachmentrevision_set.exclude(
+        if self.can_moderate and form.cleaned_data['replace']:
+            most_recent_revision = self.attachment.attachmentrevision_set.exclude(
                 id=attachment_revision.id,
                 created__lte=attachment_revision.created,
-            )
-            # Because of signalling, the files are automatically removed...
-            older_revisions.delete()
+            ).latest()
+            most_recent_revision.delete()
 
         return redirect(
             "wiki:attachments_index",


### PR DESCRIPTION
This tweaks the replace attachment functionality to behave as discussed in issue #441.  