### PR TITLE
Add option to use custom Group model with wiki

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -8,6 +8,7 @@ from django.conf import settings
 settings.configure(
     DEBUG=True,
     AUTH_USER_MODEL='testdata.CustomUser',
+    WIKI_GROUP_MODEL='testdata.CustomGroup',
     DATABASES={
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',

--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -173,6 +173,9 @@ SEARCH_VIEW = getattr(
 # other objects that are changed.
 CACHE_TIMEOUT = getattr(django_settings, 'WIKI_CACHE_TIMEOUT', 600)
 
+# Choose the Group model to use. Defaults to django's auth.Group
+GROUP_MODEL = getattr(django_settings, 'WIKI_GROUP_MODEL', 'auth.Group')
+
 ###################
 # SPAM PROTECTION #
 ###################

--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -174,6 +174,7 @@ SEARCH_VIEW = getattr(
 CACHE_TIMEOUT = getattr(django_settings, 'WIKI_CACHE_TIMEOUT', 600)
 
 # Choose the Group model to use. Defaults to django's auth.Group
+# Has no effect in Django 1.6 and below.
 GROUP_MODEL = getattr(django_settings, 'WIKI_GROUP_MODEL', 'auth.Group')
 
 ###################

--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.conf import settings as django_settings
 from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
+import django
 
 # Should urls be case sensitive?
 URL_CASE_SENSITIVE = getattr(django_settings, 'WIKI_URL_CASE_SENSITIVE', False)
@@ -174,8 +175,11 @@ SEARCH_VIEW = getattr(
 CACHE_TIMEOUT = getattr(django_settings, 'WIKI_CACHE_TIMEOUT', 600)
 
 # Choose the Group model to use. Defaults to django's auth.Group
-# Has no effect in Django 1.6 and below.
-GROUP_MODEL = getattr(django_settings, 'WIKI_GROUP_MODEL', 'auth.Group')
+# This requires `django.apps` which was introduced in Django 1.7.
+if django.VERSION < (1, 7):
+    GROUP_MODEL = 'auth.Group'
+else:
+    GROUP_MODEL = getattr(django_settings, 'WIKI_GROUP_MODEL', 'auth.Group')
 
 ###################
 # SPAM PROTECTION #

--- a/wiki/migrations/0001_initial.py
+++ b/wiki/migrations/0001_initial.py
@@ -6,6 +6,8 @@ import mptt.fields
 from django.conf import settings
 import django.db.models.deletion
 
+from wiki.conf.settings import GROUP_MODEL
+
 
 class Migration(migrations.Migration):
 
@@ -186,7 +188,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='article',
             name='group',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, help_text='Like in a UNIX file system, permissions can be given to a user according to group membership. Groups are handled through the Django auth system.', blank=True, to='auth.Group', verbose_name='group'),
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, help_text='Like in a UNIX file system, permissions can be given to a user according to group membership. Groups are handled through the Django auth system.', blank=True, to=GROUP_MODEL, verbose_name='group'),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/wiki/models/article.py
+++ b/wiki/models/article.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.db import models
 from django.db.models.signals import post_save, pre_delete
@@ -60,7 +59,7 @@ class Article(models.Model):
         on_delete=models.SET_NULL)
 
     group = models.ForeignKey(
-        Group, verbose_name=_('group'),
+        settings.GROUP_MODEL, verbose_name=_('group'),
         blank=True, null=True,
         help_text=_(
             'Like in a UNIX file system, permissions can be given to a user according to group membership. Groups are handled through the Django auth system.'),

--- a/wiki/tests/test_basic.py
+++ b/wiki/tests/test_basic.py
@@ -3,8 +3,14 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from django.test import TestCase
+from django.contrib import auth
+import django
 
+from wiki.conf import settings as wiki_settings
+from wiki.forms import Group
 from wiki.models import URLPath
+from .base import wiki_override_settings
+from .testdata.models import CustomGroup
 
 
 class URLPathTests(TestCase):
@@ -16,3 +22,16 @@ class URLPathTests(TestCase):
 
         self.assertEqual(root.parent, None)
         self.assertEqual(list(root.children.all().active()), [child])
+
+
+class CustomGroupTests(TestCase):
+    @wiki_override_settings(WIKI_GROUP_MODEL='auth.Group')
+    def test_setting(self):
+        self.assertEqual(wiki_settings.GROUP_MODEL, 'auth.Group')
+
+    def test_custom(self):
+        if django.VERSION < (1, 7):
+            self.assertEqual(Group, auth.models.Group)
+        else:
+            self.assertEqual(Group, CustomGroup)
+            self.assertEqual(wiki_settings.GROUP_MODEL, 'testdata.CustomGroup')

--- a/wiki/tests/test_models.py
+++ b/wiki/tests/test_models.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 from django.test.testcases import TestCase
 from django.contrib.sites.models import Site
-from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
 from django.conf.urls import url
 User = get_user_model()
@@ -17,6 +16,15 @@ from wiki.models import (
 from wiki.managers import ArticleManager
 
 from wiki.urls import WikiURLPatterns
+
+# Backwards compatibility with Django < 1.7
+try:
+    from django.apps import apps
+except ImportError:
+    from django.contrib.auth.models import Group
+else:
+    from wiki.conf import settings
+    Group = apps.get_model(settings.GROUP_MODEL)
 
 
 class WikiCustomUrlPatterns(WikiURLPatterns):

--- a/wiki/tests/testdata/models.py
+++ b/wiki/tests/testdata/models.py
@@ -8,3 +8,7 @@ try:
         some_field = models.IntegerField(default=0)
 except ImportError:
     pass
+
+
+class CustomGroup(models.Model):
+    pass


### PR DESCRIPTION
This patch lets you use a custom `GROUP_MODEL` instead of the builtin `auth.Group`.

In a project of mine, we substituted `auth.Group` with our custom `groups.Group` model as injecting lots of functionality into `auth.Group` seemed like a big hack and it was easier this way. Unfortunately, this brings incompatibilities to 3rd party apps like this one.

This patch implements this functionality for Django 1.7 and up since it relies on `django.apps` for finding the `GROUP_MODEL` and I wasn't quite sure how to hack this change into south migrations. For Django < 1.7 it simply uses `auth.Group` despite the value of `GROUP_MODEL`.