### PR TITLE
Add WIKI_BASEURL as a configuration option for sites where the wiki isn't based off /

### DIFF
--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -49,6 +49,8 @@ CHECK_SLUG_URL_AVAILABLE = getattr(
     'WIKI_CHECK_SLUG_URL_AVAILABLE',
     True)
 
+WIKI_BASEURL = getattr (django_settings, 'WIKI_BASEURL', None)
+
 # Do we want to log IPs?
 LOG_IPS_ANONYMOUS = getattr(django_settings, 'WIKI_LOG_IPS_ANONYMOUS', True)
 LOG_IPS_USERS = getattr(django_settings, 'WIKI_LOG_IPS_USERS', False)

--- a/wiki/core/markdown/__init__.py
+++ b/wiki/core/markdown/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from wiki.conf import settings
 from wiki.core.markdown.mdx.previewlinks import PreviewLinksExtension
+from markdown.extensions.wikilinks import WikiLinkExtension
 from wiki.core.plugins import registry as plugin_registry
 import markdown
 
@@ -22,8 +23,14 @@ class ArticleMarkdown(markdown.Markdown):
     def get_markdown_extensions(self):
         kwargs = settings.MARKDOWN_KWARGS
         extensions = kwargs.get('extensions', [])
+        
         extensions += self.core_extensions()
         extensions += plugin_registry.get_markdown_extensions()
+        
+        """ Where Base URL has been specified, use that"""
+        if settings.WIKI_BASEURL != None:
+            extensions += [WikiLinkExtension(base_url=settings.WIKI_BASEURL)]
+            
         return extensions
 
 


### PR DESCRIPTION
This commit adds an additional setting (WIKI_BASEURL) that is used to provide a base URL for the Wiki itself. This is required where the wiki is not hosted off / to allow links to work properly between pages.

This is accomplished by creating and loading the WikiLinkExtension for Markdown, passing it the provided base URL path. 