### PR TITLE
Validate revision title

### DIFF
--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -188,6 +188,11 @@ class EditForm(forms.Form, SpamProtectionMixin):
         super(EditForm, self).__init__(*args, **kwargs)
 
     def clean(self):
+        """Validates form data by checking for the following
+        No new revisions have been created since user attempted to edit 
+        Revision has a title 
+        A title has 
+        """
         cd = self.cleaned_data
         if self.no_clean or self.preview:
             return cd
@@ -195,9 +200,9 @@ class EditForm(forms.Form, SpamProtectionMixin):
             raise forms.ValidationError(
                 ugettext(
                     'While you were editing, someone else changed the revision. Your contents have been automatically merged with the new contents. Please review the text below.'))
-        if 'title' not in cd:
+        if ('title' not in cd) or (not cd['title'].strip()):
             raise forms.ValidationError(
-                ugettext('Article is missing title'))
+                ugettext('Article is missing title or has an invalid title'))
         if cd['title'] == self.initial_revision.title and cd[
                 'content'] == self.initial_revision.content:
             raise forms.ValidationError(

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -187,10 +187,16 @@ class EditForm(forms.Form, SpamProtectionMixin):
 
         super(EditForm, self).__init__(*args, **kwargs)
 
+    def clean_title(self):
+        title = self.cleaned_data.get('title', None)
+        title = (title or "").strip()
+        if not title:
+            raise forms.ValidationError(ugettext('Article is missing title or has an invalid title'))
+        return title
+
     def clean(self):
         """Validates form data by checking for the following
         No new revisions have been created since user attempted to edit 
-        Revision has a title and that the title is not all whitespace characters 
         Revision title or content has changed
         """
         cd = self.cleaned_data
@@ -200,10 +206,7 @@ class EditForm(forms.Form, SpamProtectionMixin):
             raise forms.ValidationError(
                 ugettext(
                     'While you were editing, someone else changed the revision. Your contents have been automatically merged with the new contents. Please review the text below.'))
-        if ('title' not in cd) or (not cd['title'].strip()):
-            raise forms.ValidationError(
-                ugettext('Article is missing title or has an invalid title'))
-        if cd['title'] == self.initial_revision.title and cd[
+        if cd.has_key('title') and cd['title'] == self.initial_revision.title and cd[
                 'content'] == self.initial_revision.content:
             raise forms.ValidationError(
                 ugettext('No changes made. Nothing to save.'))

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -190,8 +190,8 @@ class EditForm(forms.Form, SpamProtectionMixin):
     def clean(self):
         """Validates form data by checking for the following
         No new revisions have been created since user attempted to edit 
-        Revision has a title 
-        A title has 
+        Revision has a title and that the title is not all whitespace characters 
+        Revision title or content has changed
         """
         cd = self.cleaned_data
         if self.no_clean or self.preview:

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -206,7 +206,7 @@ class EditForm(forms.Form, SpamProtectionMixin):
             raise forms.ValidationError(
                 ugettext(
                     'While you were editing, someone else changed the revision. Your contents have been automatically merged with the new contents. Please review the text below.'))
-        if cd.has_key('title') and cd['title'] == self.initial_revision.title and cd[
+        if ('title' in cd) and cd['title'] == self.initial_revision.title and cd[
                 'content'] == self.initial_revision.content:
             raise forms.ValidationError(
                 ugettext('No changes made. Nothing to save.'))

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -195,6 +195,9 @@ class EditForm(forms.Form, SpamProtectionMixin):
             raise forms.ValidationError(
                 ugettext(
                     'While you were editing, someone else changed the revision. Your contents have been automatically merged with the new contents. Please review the text below.'))
+        if 'title' not in cd:
+            raise forms.ValidationError(
+                ugettext('Article is missing title'))
         if cd['title'] == self.initial_revision.title and cd[
                 'content'] == self.initial_revision.content:
             raise forms.ValidationError(


### PR DESCRIPTION
This is in regards to issue #466. 

This PR changes the `EditForm` clean behaviour to throw a validation error when attempting to save something with no title, or with an all whitespace title.  