### PR TITLE
Fix diff and merge AJAX call server errors

### DIFF
--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -32,11 +32,11 @@ class WikiURLPatterns(object):
     article_settings_view_class = article.Settings
     article_source_view_class = article.Source
     article_plugin_view_class = article.Plugin
-    revision_change_view = article.ChangeRevisionView
-    revision_merge_view = article.merge
+    revision_change_view_class = article.ChangeRevisionView
+    revision_merge_view = staticmethod(article.merge)
 
     search_view_class = settings.SEARCH_VIEW
-    article_diff_view = article.diff
+    article_diff_view = staticmethod(article.diff)
 
     # account views
     signup_view_class = accounts.Signup
@@ -96,7 +96,7 @@ class WikiURLPatterns(object):
             # where to redirect after...
             url(
                 '^_revision/change/(?P<article_id>\d+)/(?P<revision_id>\d+)/$',
-                self.revision_change_view.as_view(),
+                self.revision_change_view_class.as_view(),
                 name='change_revision'),
             url('^_revision/preview/(?P<article_id>\d+)/$',
                 self.article_preview_view_class.as_view(),
@@ -139,7 +139,7 @@ class WikiURLPatterns(object):
                 name='source'),
             url(
                 '^(?P<article_id>\d+)/revision/change/(?P<revision_id>\d+)/$',
-                self.revision_change_view.as_view(),
+                self.revision_change_view_class.as_view(),
                 name='change_revision'),
             url(
                 '^(?P<article_id>\d+)/revision/merge/(?P<revision_id>\d+)/$',
@@ -183,7 +183,7 @@ class WikiURLPatterns(object):
                 name='source'),
             url(
                 '^(?P<path>.+/|)_revision/change/(?P<revision_id>\d+)/$',
-                self.revision_change_view.as_view(),
+                self.revision_change_view_class.as_view(),
                 name='change_revision'),
             url(
                 '^(?P<path>.+/|)_revision/merge/(?P<revision_id>\d+)/$',
@@ -199,7 +199,8 @@ class WikiURLPatterns(object):
         ]
         return urlpatterns
 
-    def get_plugin_urls(self):
+    @staticmethod
+    def get_plugin_urls():
         urlpatterns = []
         for plugin in list(registry.get_plugins().values()):
             slug = getattr(plugin, 'slug', None)


### PR DESCRIPTION
Fix a bug introduced in 0e3d363dcdc39167d652bcd1fe44d838df131cef where the function pointers to diff and merge view functions are attached as an instance method on the class instead of a staticmethod. This caused 'self' to be passed as first argument to these views, resulting in stacktraces for these views.

This was new to me, but attaching a function outside of the constructor of the class renders
that function to be declared as an instance method.

Performing the same operation inside the `__init__(self)` constructor will automatically yield a staticmethod.

Examples:

The following will produce an instancemethod:

```
def func(req, *args, **kargs):
    pass

class MyClass(object):
    some_view = func
```

Where a call to MyClass().some_view will have the following parameters: `(self, req, *args, **kwargs)`

However, if this is done inside the constructor, func will automatically be decorated with `@staticmethod`:

```
from module import func

class MyClass(object):
    def __init__(self):
        self.my_view = func
```

MyClass().my_view() is now a static method.

Until the `diff` and `merge` views are converted to class-based, the `diff` and `merge` view functions needs to be decorated with `staticmethod()` to prevent passing along the object reference upon invocation.

Hope you can get this merged soon because my inbox is hammered with stacktraces triggered by our dear friend googlebot.

Cheers

Fixes #486 
