### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -103,7 +103,7 @@ maintain the order due to database relational constraints:
 
 .. code-block:: python
 
-    'django.contrib.sites', # django 1.6.2
+    'django.contrib.sites', # django 1.6.2+
     'django.contrib.humanize',
     'django_nyt',
     'mptt',


### PR DESCRIPTION
Add trailing '+' after version number on comment indicating that 'django.contrib.sites' should be added to INSTALLED_APPS for Django versions 1.6.2(+)