### PR TITLE
Add default arguments that Django 1.9 wants explicitly

### DIFF
--- a/wiki/migrations/0001_initial.py
+++ b/wiki/migrations/0001_initial.py
@@ -152,9 +152,9 @@ class Migration(migrations.Migration):
                 ('rght', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('tree_id', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('level', models.PositiveIntegerField(db_index=True, editable=False)),
-                ('article', models.ForeignKey(editable=False, to='wiki.Article', verbose_name='Cache lookup value for articles')),
-                ('parent', mptt.fields.TreeForeignKey(related_name='children', null=True, blank=True, to='wiki.URLPath')),
-                ('site', models.ForeignKey(to='sites.Site')),
+                ('article', models.ForeignKey(help_text='This field is automatically updated, but you need to populate it when creating a new URL path.', on_delete=django.db.models.deletion.CASCADE, to='wiki.Article', verbose_name='Lookup value')),
+                ('parent', mptt.fields.TreeForeignKey(blank=True, help_text='Position of URL path in the tree.', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='children', to='wiki.URLPath')),
+                ('site', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='sites.Site')),
             ],
             options={
                 'verbose_name_plural': 'URL paths',


### PR DESCRIPTION
Models didn't appear in sync with migrations (created under Django 1.7) running Django 1.9