### PR TITLE
Undo weird old changes to exception handling

### DIFF
--- a/wiki/decorators.py
+++ b/wiki/decorators.py
@@ -141,8 +141,7 @@ def get_article(func=None, can_read=True, can_write=False,
             article = get_object_or_404(articles, id=article_id)
             try:
                 urlpath = models.URLPath.objects.get(articles__article=article)
-            except models.URLPath.DoesNotExist as noarticle:
-                models.URLPath.MultipleObjectsReturned = noarticle
+            except (models.URLPath.DoesNotExist, models.URLPath.MultipleObjectsReturned):
                 urlpath = None
 
         else:

--- a/wiki/plugins/attachments/models.py
+++ b/wiki/plugins/attachments/models.py
@@ -221,8 +221,7 @@ def on_attachment_revision_pre_save(**kwargs):
             instance.revision_number = previous_revision.revision_number + 1
         # NB! The above should not raise the below exception, but somehow
         # it does.
-        except AttachmentRevision.DoesNotExist as noattach:
-            Attachment.DoesNotExist = noattach
+        except (AttachmentRevision.DoesNotExist, Attachment.DoesNotExist):
             instance.revision_number = 1
 
 


### PR DESCRIPTION
I have absolutely no clue what the old code was trying to do. 
The relevant commit (791888eec2d64c80bb3abd0e43fbfcdb1b91a18a) seems to just update the code to the new exception syntax except for these two places. 

What it ended up doing was overwriting DoesNotExcept with an instance of another DoesNotExist. The next time this exception was supposed to be called it failed and created another exception (TypeError: 'DoesNotExist' object is not callable). 