### PR TITLE
Fix 'AttachmentSearchView' object has no attribute 'get_form'

### DIFF
--- a/wiki/plugins/attachments/views.py
+++ b/wiki/plugins/attachments/views.py
@@ -473,6 +473,4 @@ class AttachmentSearchView(ArticleMixin, ListView):
         kwargs.update(kwargs_article)
         kwargs.update(kwargs_listview)
         kwargs['selected_tab'] = 'attachments'
-        if 'form' not in kwargs:
-            kwargs['form'] = self.get_form()
         return kwargs

--- a/wiki/plugins/attachments/views.py
+++ b/wiki/plugins/attachments/views.py
@@ -444,13 +444,12 @@ class AttachmentSearchView(ArticleMixin, ListView):
 
     @method_decorator(get_article(can_write=True))
     def dispatch(self, request, article, *args, **kwargs):
-        return super(
-            AttachmentSearchView,
-            self).dispatch(
+        return super(AttachmentSearchView, self).dispatch(
             request,
             article,
             *args,
-            **kwargs)
+            **kwargs
+        )
 
     def get_queryset(self):
         self.query = self.request.GET.get('query', None)

--- a/wiki/templatetags/wiki_tags.py
+++ b/wiki/templatetags/wiki_tags.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals
-# -*- coding: utf-8 -*-
+
 import re
 
 from django.conf import settings as django_settings


### PR DESCRIPTION
Demo server error:

```
Internal Server Error: /Test/_plugin/attachments/search/

AttributeError at /Test/_plugin/attachments/search/
'AttachmentSearchView' object has no attribute 'get_form'
```