### PR TITLE
account settings page

### DIFF
--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -204,7 +204,7 @@ class EditForm(forms.Form, SpamProtectionMixin):
 
     def clean(self):
         """Validates form data by checking for the following
-        No new revisions have been created since user attempted to edit 
+        No new revisions have been created since user attempted to edit
         Revision title or content has changed
         """
         cd = self.cleaned_data
@@ -633,3 +633,20 @@ class UserCreationForm(UserCreationForm):
     class Meta:
         model = User
         fields = ("username", "email")
+
+class UserUpdateForm(forms.ModelForm):
+    password1 = forms.CharField(label="New password", widget=forms.PasswordInput(), required=False)
+    password2 = forms.CharField(label="Confirm password", widget=forms.PasswordInput(), required=False)
+
+    def clean(self):
+        password1 = self.cleaned_data.get('password1')
+        password2 = self.cleaned_data.get('password2')
+
+        if password1 and password1 != password2:
+            raise forms.ValidationError(_("Passwords don't match"))
+
+        return self.cleaned_data
+
+    class Meta:
+        model = User
+        fields = ['email']

--- a/wiki/templates/wiki/accounts/account_settings.html
+++ b/wiki/templates/wiki/accounts/account_settings.html
@@ -1,0 +1,14 @@
+{% extends "wiki/base.html" %}
+{% load i18n wiki_tags sekizai_tags %}
+
+{% block wiki_pagetitle %}{% trans "Account Settings" %}{% endblock %}
+
+{% block wiki_contents %}
+<h1 class="page-header">{% trans "Account Settings" %}</h1>
+<form class="form-horizontal" action="" method="post">{% csrf_token %}
+    {% wiki_form form %}
+    <button type="submit" name="save_changes" class="btn btn-primary btn-lg">
+      {% trans "Update" %}
+    </button>
+</form>
+{% endblock %}

--- a/wiki/templates/wiki/base_site.html
+++ b/wiki/templates/wiki/base_site.html
@@ -65,12 +65,14 @@
                       {% trans "Log out" %}
                     </a>
                   </li>
+                  {% if "ACCOUNT_HANDLING"|wiki_settings %}
                   <li>
-                    <a href="{% url 'wiki:update' %}">
+                    <a href="{% url 'wiki:profile_update' %}">
                       <i class="fa fa-gear"></i>
                       {% trans "Account Settings" %}
                     </a>
                   </li>
+                  {% endif %}
                   {% if user.is_superuser %}
                   <li>
                     <a href="{% url 'wiki:deleted_list' %}">

--- a/wiki/templates/wiki/base_site.html
+++ b/wiki/templates/wiki/base_site.html
@@ -65,6 +65,12 @@
                       {% trans "Log out" %}
                     </a>
                   </li>
+                  <li>
+                    <a href="{% url 'wiki:update' %}">
+                      <i class="fa fa-gear"></i>
+                      {% trans "Account Settings" %}
+                    </a>
+                  </li>
                   {% if user.is_superuser %}
                   <li>
                     <a href="{% url 'wiki:deleted_list' %}">

--- a/wiki/templatetags/wiki_tags.py
+++ b/wiki/templatetags/wiki_tags.py
@@ -190,3 +190,7 @@ def plugin_enabled(plugin_name):
                          'wiki.plugins.attachments'
     """
     return plugin_name in django_settings.INSTALLED_APPS
+
+@register.filter
+def wiki_settings(name):
+    return getattr(settings, name, "")

--- a/wiki/tests/test_managers.py
+++ b/wiki/tests/test_managers.py
@@ -14,7 +14,7 @@ from wiki.models import Article, URLPath
 from wiki.plugins.attachments.models import Attachment
 
 
-class ArticlManagerTests(ArticleWebTestBase):
+class ArticleManagerTests(ArticleWebTestBase):
 
     def test_queryset_methods_directly_on_manager(self):
 

--- a/wiki/tests/test_template_filters.py
+++ b/wiki/tests/test_template_filters.py
@@ -380,3 +380,16 @@ class PluginEnabled(TemplateTestCase):
     def test_true(self):
         output = self.render({})
         self.assertIn('It is enabled', output)
+
+
+class WikiSettings(TemplateTestCase):
+
+    template = """
+        {% load wiki_tags %}
+        {% if "ACCOUNT_HANDLING"|wiki_settings %}It is enabled{% endif %}
+    """
+
+    @wiki_override_settings(WIKI_ACCOUNT_HANDLING=lambda *args: True)
+    def test_setting(self):
+        output = self.render({})
+        self.assertIn('It is enabled', output)

--- a/wiki/tests/test_views.py
+++ b/wiki/tests/test_views.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import
 import pprint
 
 from django.contrib.auth import authenticate
-from django.contrib.auth import get_user_model
-User = get_user_model()
 
 from .base import ArticleWebTestBase, WebTestBase
 

--- a/wiki/tests/test_views.py
+++ b/wiki/tests/test_views.py
@@ -4,6 +4,10 @@ from __future__ import absolute_import
 
 import pprint
 
+from django.contrib.auth import authenticate
+from django.contrib.auth import get_user_model
+User = get_user_model()
+
 from .base import ArticleWebTestBase, WebTestBase
 
 from django.core.urlresolvers import reverse
@@ -301,6 +305,7 @@ class SearchViewTest(ArticleWebTestBase):
         response = c.get(reverse('wiki:search'), {'q': ''})
         self.assertFalse(response.context['articles'])
 
+
 class DeletedListViewTest(ArticleWebTestBase):
 
     def test_deleted_articles_list(self):
@@ -328,3 +333,17 @@ class DeletedListViewTest(ArticleWebTestBase):
 
         response = c.get(reverse('wiki:deleted_list'))
         self.assertContains(response, 'Delete Me')
+
+
+class UpdateProfileViewTest(ArticleWebTestBase):
+
+    def test_update_profile(self):
+        c = self.c
+
+        response = c.post(reverse('wiki:profile_update'),
+        {"email":"test@test.com", "password1":"newPass", "password2":"newPass"}, follow=True)
+
+        test_auth = authenticate(username='admin', password='newPass')
+
+        self.assertNotEqual(test_auth, None)
+        self.assertEqual(test_auth.email, 'test@test.com')

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -42,6 +42,7 @@ class WikiURLPatterns(object):
     signup_view_class = accounts.Signup
     login_view_class = accounts.Login
     logout_view_class = accounts.Logout
+    settings_view_class = accounts.Update
 
     # deleted list view
     deleted_list_view_class = deleted_list.DeletedListView
@@ -99,6 +100,9 @@ class WikiURLPatterns(object):
             url('^_accounts/login/$',
                 self.login_view_class.as_view(),
                 name='login'),
+            url('^_accounts/settings/$',
+                self.settings_view_class.as_view(),
+                name='update'),
         ]
         return urlpatterns
 

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -42,7 +42,7 @@ class WikiURLPatterns(object):
     signup_view_class = accounts.Signup
     login_view_class = accounts.Login
     logout_view_class = accounts.Logout
-    settings_view_class = accounts.Update
+    profile_update_view_class = accounts.Update
 
     # deleted list view
     deleted_list_view_class = deleted_list.DeletedListView
@@ -102,8 +102,8 @@ class WikiURLPatterns(object):
                     self.login_view_class.as_view(),
                     name='login'),
                 url('^_accounts/settings/$',
-                    self.settings_view_class.as_view(),
-                    name='update'),
+                    self.profile_update_view_class.as_view(),
+                    name='profile_update'),
             ]
         else:
             urlpatterns = []


### PR DESCRIPTION
https://github.com/django-wiki/django-wiki/issues/490
Adds a simple page where users can change their password and email address. It looks like this:
![screenshot](http://i.imgur.com/0rmkRei.png)

I also fixed a small typo ("ArticlManagerTests" -> "ArticleManagerTests")