### PR TITLE
wiki.core doesn't have settings.py; In fact wiki.conf does

### DIFF
--- a/wiki/plugins/haystack/__init__.py
+++ b/wiki/plugins/haystack/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from wiki.core import settings
+from wiki.conf import settings
 from wiki.core import permissions
 from wiki import models
 


### PR DESCRIPTION
Addressing:

File "/Users/neo/.virtualenvs/pp_new/lib/python3.5/site-packages/wiki/plugins/haystack/__init__.py", line 3, in <module>
    from wiki.core import settings
ImportError: cannot import name 'settings'

Process finished with exit code 1