### PR TITLE
Fix duplicate search results

### DIFF
--- a/wiki/managers.py
+++ b/wiki/managers.py
@@ -43,7 +43,7 @@ class ArticleQuerySet(QuerySet):
             q = self.filter(Q(other_read=True) |
                             Q(owner=user) |
                             (Q(group__user=user) & Q(group_read=True))
-                            )
+                            ).distinct()
         return q
 
     def can_write(self, user):

--- a/wiki/views/article.py
+++ b/wiki/views/article.py
@@ -595,7 +595,7 @@ class SearchView(ListView):
         if not permissions.can_moderate(
                 models.URLPath.root().article,
                 self.request.user):
-            articles = articles.active().can_read(self.request.user)
+            articles = articles.active().can_read(self.request.user).distinct()
         return articles
 
     def get_context_data(self, **kwargs):

--- a/wiki/views/article.py
+++ b/wiki/views/article.py
@@ -595,7 +595,7 @@ class SearchView(ListView):
         if not permissions.can_moderate(
                 models.URLPath.root().article,
                 self.request.user):
-            articles = articles.active().can_read(self.request.user).distinct()
+            articles = articles.active().can_read(self.request.user)
         return articles
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
If searching for articles while logged in, but without permissions to edit the article, the search returns duplicates.  More specifically it returns a duplicate for each member of the group the article is owned by.

This is because of the query produced by the many-to-many relation using `LEFT OUTER JOIN`. 
I read in an old issue that distinct was deliberately omitted because of performance issues so I only added it to the one place I know there is a bug.
Might be smarter to add it in `can_read` instead, but I'm not sure where the method is used and if it would lead to performance issues.