### PR TITLE
Lowercase slugs when creating new pages with [[Like This]].

### DIFF
--- a/wiki/decorators.py
+++ b/wiki/decorators.py
@@ -105,7 +105,7 @@ def get_article(func=None, can_read=True, can_write=False,  # noqa
                     return HttpResponseRedirect(
                         reverse(
                             "wiki:create", kwargs={'path': parent.path, }) +
-                        "?slug=%s" % pathlist[-1])
+                        "?slug=%s" % pathlist[-1].lower())
                 except models.URLPath.DoesNotExist:
                     return HttpResponseNotFound(
                         render_to_string(

--- a/wiki/tests/test_views.py
+++ b/wiki/tests/test_views.py
@@ -58,10 +58,18 @@ class ArticleViewViewTests(ArticleWebTestBase):
 
     def test_redirects_to_create_if_the_slug_is_unknown(self):
 
-        response = self.get_by_path('Unknown/')
+        response = self.get_by_path('unknown/')
         self.assertRedirects(
             response,
-            reverse('wiki:create', kwargs={'path': ''}) + '?slug=Unknown'
+            reverse('wiki:create', kwargs={'path': ''}) + '?slug=unknown'
+        )
+
+    def test_redirects_to_create_with_lowercased_slug(self):
+
+        response = self.get_by_path('Unknown_Linked_Page/')
+        self.assertRedirects(
+            response,
+            reverse('wiki:create', kwargs={'path': ''}) + '?slug=unknown_linked_page'
         )
 
     def test_article_list_update(self):


### PR DESCRIPTION
Currently in django-wiki slugs must be lowercase. You can create a wiki link [[Like This]] in any page content, and the system redirects you to the create form if you click it (which is expected behaviour). However, the slug field is set to "Like_This", which fails validation because slugs must be lowercase.

This change lowercases the slug before the form loads, so that the user can proceed to add their new page without validation error.

Auto test added to `wiki/tests/test_views.py`