### PR TITLE
Refactor json_view, fixes 500 errors when looking up 404 paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,6 @@ assets:  ## Build CSS files
 	lessc wiki/static/wiki/bootstrap/less/wiki/wiki-bootstrap.less wiki/static/wiki/bootstrap/css/wiki-bootstrap.css
 	lessc -x wiki/static/wiki/bootstrap/less/wiki/wiki-bootstrap.less wiki/static/wiki/bootstrap/css/wiki-bootstrap.min.css
 
-dist: clean assets  ## Generate source dist and wheels
+dist: clean assets  ## Generate wheels distribution
 	python setup.py bdist_wheel
 	ls -l dist

--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,13 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
-release: sdist  ## Generate and upload release to PyPi
+release: dist  ## Generate and upload release to PyPi
 	twine upload -s dist/*
 
 assets:  ## Build CSS files
 	lessc wiki/static/wiki/bootstrap/less/wiki/wiki-bootstrap.less wiki/static/wiki/bootstrap/css/wiki-bootstrap.css
 	lessc -x wiki/static/wiki/bootstrap/less/wiki/wiki-bootstrap.less wiki/static/wiki/bootstrap/css/wiki-bootstrap.min.css
 
-sdist: clean assets  ## Generate source dist and wheels
-	python setup.py sdist
+dist: clean assets  ## Generate source dist and wheels
 	python setup.py bdist_wheel
 	ls -l dist

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,7 +12,7 @@ introduce any backwards incompatible changes.
 django-wiki 0.2.2 (unreleased master branch)
 --------------------------------------------
 
- * Changes go here
+ * Remove ``wiki.decorators.json_view``, fixes server errors when resolving 404 links #604
 
 
 django-wiki 0.2.1

--- a/wiki/core/utils.py
+++ b/wiki/core/utils.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+import json
+from django.http.response import HttpResponse
+
 
 try:
     from importlib import import_module
@@ -14,3 +17,14 @@ def get_class_from_str(class_path):
     module_path, klass_name = class_path.rsplit('.', 1)
     module = import_module(module_path)
     return getattr(module, klass_name)
+
+
+def object_to_json_response(obj, status=200):
+    """
+    Given an object, returns an HttpResponse object with a JSON serialized
+    version of that object
+    """
+    data = json.dumps(obj, ensure_ascii=False)
+    response = HttpResponse(content_type='application/json', status=status)
+    response.write(data)
+    return response

--- a/wiki/core/utils.py
+++ b/wiki/core/utils.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 import json
+from importlib import import_module
+
 from django.http.response import HttpResponse
-
-
-try:
-    from importlib import import_module
-except ImportError:
-    # Python 2.6 fallback
-    from django.utils.importlib import import_module
 
 
 def get_class_from_str(class_path):

--- a/wiki/decorators.py
+++ b/wiki/decorators.py
@@ -1,35 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import json
 from functools import wraps
 
 from django.core.urlresolvers import reverse
-from django.http import (HttpResponse, HttpResponseForbidden,
-                         HttpResponseNotFound, HttpResponseRedirect)
+from django.http import (HttpResponseForbidden, HttpResponseNotFound,
+                         HttpResponseRedirect)
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils.http import urlquote
 from six.moves import filter
 from wiki.conf import settings
 from wiki.core.exceptions import NoRootURL
-
-
-def json_view(func):
-    def wrap(request, *args, **kwargs):
-        obj = func(request, *args, **kwargs)
-        if isinstance(obj, HttpResponse):
-            # Special behaviour: If it's a redirect, for instance
-            # because of login protection etc. just return
-            # the redirect
-            if obj.status_code == 301 or obj.status_code == 302:
-                return obj
-        data = json.dumps(obj, ensure_ascii=False)
-        status = kwargs.get('status', 200)
-        response = HttpResponse(content_type='application/json', status=status)
-        response.write(data)
-        return response
-    return wrap
 
 
 def response_forbidden(request, article, urlpath):
@@ -44,9 +26,10 @@ def response_forbidden(request, article, urlpath):
         return HttpResponseForbidden(
             render_to_string(
                 "wiki/permission_denied.html",
-                context={'article': article,
-                         'urlpath': urlpath},
-                request=request))
+                context={'article': article, 'urlpath': urlpath},
+                request=request
+            )
+        )
 
 
 # TODO: This decorator is too complex (C901)

--- a/wiki/plugins/links/views.py
+++ b/wiki/plugins/links/views.py
@@ -3,19 +3,20 @@ from __future__ import absolute_import, unicode_literals
 from django.utils.decorators import method_decorator
 from django.views.generic.base import View
 from wiki import models
-from wiki.decorators import get_article, json_view
+from wiki.core.utils import object_to_json_response
+from wiki.decorators import get_article
 
 
 class QueryUrlPath(View):
 
-    # TODO: get_article does not actually support JSON responses
-    @method_decorator(json_view)
     @method_decorator(get_article(can_read=True))
     def dispatch(self, request, article, *args, **kwargs):
         max_num = kwargs.pop('max_num', 20)
         # TODO: Move this import when circularity issue is resolved
         # https://github.com/django-wiki/django-wiki/issues/23
         query = request.GET.get('query', None)
+
+        matches = []
 
         if query:
             matches = models.URLPath.objects.can_read(
@@ -24,8 +25,11 @@ class QueryUrlPath(View):
                 article__current_revision__deleted=False,
             )
             matches = matches.select_related_common()
-            return [("[%s](wiki:%s)") %
-                    (m.article.current_revision.title, '/' +
-                     m.path.strip("/")) for m in matches[:max_num]]
+            matches = [
+                "[{title:s}](wiki:{url:s})".format(
+                    title=m.article.current_revision.title,
+                    url='/' + m.path.strip("/")
+                ) for m in matches[:max_num]
+            ]
 
-        return []
+        return object_to_json_response(matches)

--- a/wiki/tests/test_utils.py
+++ b/wiki/tests/test_utils.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from wiki.core.utils import object_to_json_response
+
+
+class TestUtils(TestCase):
+
+    def test_object_to_json(self):
+        """
+        Simple test, the actual serialization happens in json.dumps and we
+        don't wanna test this core module in depth.
+        """
+        obj = []
+        response = object_to_json_response(obj)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"[]")

--- a/wiki/views/article.py
+++ b/wiki/views/article.py
@@ -23,7 +23,8 @@ from wiki.core import permissions
 from wiki.core.diff import simple_merge
 from wiki.core.exceptions import NoRootURL
 from wiki.core.plugins import registry as plugin_registry
-from wiki.decorators import get_article, json_view
+from wiki.core.utils import object_to_json_response
+from wiki.decorators import get_article
 from wiki.views.mixins import ArticleMixin
 
 log = logging.getLogger(__name__)
@@ -788,7 +789,6 @@ class Preview(ArticleMixin, TemplateView):
         return ArticleMixin.get_context_data(self, **kwargs)
 
 
-@json_view
 def diff(request, revision_id, other_revision_id=None):
 
     revision = get_object_or_404(models.ArticleRevision, id=revision_id)
@@ -807,7 +807,9 @@ def diff(request, revision_id, other_revision_id=None):
     if not other_revision or other_revision.title != revision.title:
         other_changes.append((_('New title'), revision.title))
 
-    return dict(diff=list(diff), other_changes=other_changes)
+    return object_to_json_response(
+        dict(diff=list(diff), other_changes=other_changes)
+    )
 
 # TODO: Throw in a class-based view
 


### PR DESCRIPTION
Fixes errors of this type:

```
Internal Server Error: /Test/tttt/dddd/_plugin/links/json/query-urlpath/

TypeError at /Test/tttt/dddd/_plugin/links/json/query-urlpath/
<HttpResponseNotFound status_code=404, "text/html; charset=utf-8"> is not JSON serializable
```