### PR TITLE
Change verbose_name in migration to avoid django asking for migration updates

### DIFF
--- a/wiki/migrations/0001_initial.py
+++ b/wiki/migrations/0001_initial.py
@@ -150,7 +150,7 @@ class Migration(migrations.Migration):
                 ('rght', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('tree_id', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('level', models.PositiveIntegerField(db_index=True, editable=False)),
-                ('article', models.ForeignKey(help_text='This field is automatically updated, but you need to populate it when creating a new URL path.', on_delete=django.db.models.deletion.CASCADE, to='wiki.Article', verbose_name='Lookup value')),
+                ('article', models.ForeignKey(help_text='This field is automatically updated, but you need to populate it when creating a new URL path.', on_delete=django.db.models.deletion.CASCADE, to='wiki.Article', verbose_name='article')),
                 ('parent', mptt.fields.TreeForeignKey(blank=True, help_text='Position of URL path in the tree.', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='children', to='wiki.URLPath')),
                 ('site', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='sites.Site')),
             ],


### PR DESCRIPTION
Removes this for `makemigrations` on current wiki 0.2 and 0.2.1 release:

```
Migrations for 'wiki':
  0002_auto_20170319_0118.py:
    - Alter field article on urlpath
```