### PR TITLE
Every instantiation of ArticleMarkdown makes settings.MARKDOWN_KWARGS grow

### DIFF
--- a/wiki/core/markdown/__init__.py
+++ b/wiki/core/markdown/__init__.py
@@ -13,8 +13,7 @@ from wiki.core.plugins import registry as plugin_registry
 class ArticleMarkdown(markdown.Markdown):
 
     def __init__(self, article, preview=False, *args, **kwargs):
-        kwargs = settings.MARKDOWN_KWARGS
-        kwargs['extensions'] = self.get_markdown_extensions()
+        kwargs = {'extensions': self.get_markdown_extensions()}
         markdown.Markdown.__init__(self, *args, **kwargs)
         self.article = article
         self.preview = preview


### PR DESCRIPTION
Python 3.6.0, Django 1.11.

In ArticleMarkdown.__init__ the result of a call to get_markdown_extensions is written directly to settings.MARKDOWN_KWARGS, that is simultaneously used by get_markdown_extensions as a source, hence settings.MARKDOWN_KWARGS grows with every instantiation of ArticleMarkdown.