### PR TITLE
Added new image size option

### DIFF
--- a/wiki/plugins/images/markdown_extensions.py
+++ b/wiki/plugins/images/markdown_extensions.py
@@ -8,7 +8,7 @@ from django.template.loader import render_to_string
 from wiki.plugins.images import models, settings
 
 IMAGE_RE = re.compile(
-    r'.*(\[image\:(?P<id>\d+)(\s+align\:(?P<align>right|left))?(\s+size\:(?P<size>default|small|medium|large))?\s*\]).*',
+    r'.*(\[image\:(?P<id>\d+)(\s+align\:(?P<align>right|left))?(\s+size\:(?P<size>default|small|medium|large|orig))?\s*\]).*',
     re.IGNORECASE)
 
 class ImageExtension(markdown.Extension):
@@ -69,6 +69,7 @@ class ImagePreprocessor(markdown.preprocessors.Preprocessor):
                     line = None
                 else:
                     caption_placeholder = "{{{IMAGECAPTION}}}"
+                    width = size.split("x")[0] if size else None
                     html = render_to_string(
                         "wiki/plugins/images/render.html",
                         context={
@@ -76,7 +77,7 @@ class ImagePreprocessor(markdown.preprocessors.Preprocessor):
                             'caption': caption_placeholder,
                             'align': alignment,
                             'size': size,
-                            'width': size.split("x")[0],
+                            'width': width
                         })
                     html_before, html_after = html.split(caption_placeholder)
                     placeholder_before = self.markdown.htmlStash.store(

--- a/wiki/plugins/images/settings.py
+++ b/wiki/plugins/images/settings.py
@@ -16,7 +16,8 @@ THUMBNAIL_SIZES = getattr(django_settings, 'WIKI_IMAGES_THUMBNAIL_SIZES', {
     'default': '250x250',
     'small': '150x150',
     'medium': '300x300',
-    'large': '500x500'
+    'large': '500x500',
+    'orig': None
 })
 
 # Storage backend to use, default is to use the same as the rest of the

--- a/wiki/plugins/images/settings.py
+++ b/wiki/plugins/images/settings.py
@@ -11,6 +11,14 @@ APP_LABEL = None
 # Where to store images
 IMAGE_PATH = getattr(django_settings, 'WIKI_IMAGES_PATH', "wiki/images/%aid/")
 
+# Sizes for image thumbnails
+THUMBNAIL_SIZES = getattr(django_settings, 'WIKI_IMAGES_THUMBNAIL_SIZES', {
+    'default': '250x250',
+    'small': '150x150',
+    'medium': '300x300',
+    'large': '500x500'
+})
+
 # Storage backend to use, default is to use the same as the rest of the
 # wiki, which is set in WIKI_STORAGE_BACKEND, but you can override it
 # with WIKI_IMAGES_STORAGE_BACKEND

--- a/wiki/plugins/images/templates/wiki/plugins/images/render.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/render.html
@@ -3,8 +3,8 @@
 
   NB! Watch out for line breaks, markdown might add <br />s and <p>s.
 {% endcomment %}{% with image.current_revision.imagerevision as revision %}{% spaceless %}
-<figure class="thumbnail{% if align %} pull-{{ align }}{% endif %}" style="width: 250px;">
-  {% thumbnail revision.image "250x250" as thumb %}
+<figure class="thumbnail{% if align %} pull-{{ align }}{% endif %}" style="width: {{ width }}px;">
+  {% thumbnail revision.image size as thumb %}
     <a href="{{ revision.image.url }}">
       <img src="{{ thumb.url }}" alt="{{ revision.get_filename }}" />
     </a>

--- a/wiki/plugins/images/templates/wiki/plugins/images/render.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/render.html
@@ -3,7 +3,7 @@
 
   NB! Watch out for line breaks, markdown might add <br />s and <p>s.
 {% endcomment %}{% with image.current_revision.imagerevision as revision %}{% spaceless %}
-<figure class="thumbnail{% if align %} pull-{{ align }}{% endif %} {% if width %} style="width: {{ width }}px; {% endif %}">
+<figure class="thumbnail{% if align %} pull-{{ align }}{% endif %}" {% if width %} style="width: {{ width }}px;" {% endif %}>
     <a href="{{ revision.image.url }}">
 {% if size %}
   {% thumbnail revision.image size upscale=False as thumb %}

--- a/wiki/plugins/images/templates/wiki/plugins/images/render.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/render.html
@@ -3,16 +3,20 @@
 
   NB! Watch out for line breaks, markdown might add <br />s and <p>s.
 {% endcomment %}{% with image.current_revision.imagerevision as revision %}{% spaceless %}
-<figure class="thumbnail{% if align %} pull-{{ align }}{% endif %}" style="width: {{ width }}px;">
-  {% thumbnail revision.image size as thumb %}
+<figure class="thumbnail{% if align %} pull-{{ align }}{% endif %} {% if width %} style="width: {{ width }}px; {% endif %}">
     <a href="{{ revision.image.url }}">
+{% if size %}
+  {% thumbnail revision.image size upscale=False as thumb %}
       <img src="{{ thumb.url }}" alt="{{ revision.get_filename }}" />
-    </a>
-    {% empty %}
-    <div class="caption">
-      <em>{% trans "Image not found" %}</em>
-    </div>
+  {% empty %}
+      <div class="caption">
+        <em>{% trans "Image not found" %}</em>
+      </div>
   {% endthumbnail %}
+{% else %}
+      <img src="{{ revision.image.url }}" alt="{{ revision.get_filename }}" />
+{% endif %}
+    </a>
   <figcaption class="caption">{{ caption|safe }}</figcaption>
 </figure>
 {% endspaceless %}{% endwith %}

--- a/wiki/plugins/images/templates/wiki/plugins/images/sidebar.html
+++ b/wiki/plugins/images/templates/wiki/plugins/images/sidebar.html
@@ -119,8 +119,8 @@ function insert_image(image_id) {
   {% trans "How to use images" %}
 </h4>
 
-<p>{% trans "After uploading an image, it is attached to this particular artice and can be used only here. Other users may replace the image, but older versions are kept. You probably want to show the image with a nice caption. To achieve this, press the Insert button and fill in the caption fields and possibly choose to have you image floating right or left of the content. You can use Markdown in the caption. The markdown code syntax for images looks like this, possible values for align are left and right:" %}<br />
-<pre>[image:id align:right]
+<p>{% trans "After uploading an image, it is attached to this particular article and can be used only here. Other users may replace the image, but older versions are kept. To show the image press the Insert button and fill in the caption field and possibly choose to have your image floating right or left of the content. You can use markdown in the caption. The markdown code syntax for images looks like this, possible values for align are left | right and for size are small | medium | large | orig | default:" %}<br />
+<pre>[image:id align:right size:orig]
     caption indented by 4 spaces</pre>
 </p>
 

--- a/wiki/plugins/images/tests/test_views.py
+++ b/wiki/plugins/images/tests/test_views.py
@@ -15,6 +15,12 @@ from ..wiki_plugin import ImagePlugin
 
 class ImageTests(ArticleWebTestBase):
 
+    def assertRegexp(self, a, b):
+        if sys.version_info >= (3,2):
+            return self.assertRegex(a, b)
+        else:
+            return self.assertRegexpMatches(a, b)
+
     def setUp(self):
         super(ImageTests, self).setUp()
         self.article = self.root_article

--- a/wiki/plugins/images/tests/test_views.py
+++ b/wiki/plugins/images/tests/test_views.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, unicode_literals
 
 import base64
+import sys
 from io import BytesIO
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -15,7 +16,7 @@ from ..wiki_plugin import ImagePlugin
 
 class ImageTests(ArticleWebTestBase):
 
-    def assertRegexp(self, a, b):
+    def _assertRegex(self, a, b):
         if sys.version_info >= (3,2):
             return self.assertRegex(a, b)
         else:
@@ -98,7 +99,7 @@ class ImageTests(ArticleWebTestBase):
                                       "html_image",
                                       title="TestImage",
                                       content=cont)
-        if (image):
+        if image:
             self._create_test_image(urlpath.path)
         return urlpath.article.render()
 
@@ -116,7 +117,7 @@ class ImageTests(ArticleWebTestBase):
                      '<a href="' + image_rev.image.name + '">'
                      '<img alt="test\.gif" src="cache/.*\.jpg">'
                      '</a><figcaption class="caption"></figcaption></figure>' )
-        self.assertRegex(output, expected)
+        self._assertRegex(output, expected)
 
     def test_image_large_right(self):
         output = self.get_article("[image:1 align:right size:large]", True)
@@ -125,7 +126,7 @@ class ImageTests(ArticleWebTestBase):
                      '<a href="' + image_rev.image.name + '">'
                      '<img alt="test\.gif" src="cache/.*\.jpg"></a>'
                      '<figcaption class="caption"></figcaption></figure>' )
-        self.assertRegex(output, expected)
+        self._assertRegex(output, expected)
 
     def test_image_orig(self):
         output = self.get_article("[image:1 size:orig]", True)

--- a/wiki/plugins/images/tests/test_views.py
+++ b/wiki/plugins/images/tests/test_views.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.urlresolvers import reverse
 from wiki.core.plugins import registry as plugin_registry
+from wiki.models import URLPath
 from wiki.tests.base import ArticleWebTestBase
 
 from .. import models
@@ -43,7 +44,7 @@ class ImageTests(ArticleWebTestBase):
         )
         return filestream
 
-    def _create_test_image(self):
+    def _create_test_image(self, path):
         # Get the form index
         plugin_index = -1
         for cnt, plugin_instance in enumerate(plugin_registry.get_sidebar()):
@@ -51,7 +52,7 @@ class ImageTests(ArticleWebTestBase):
                 plugin_index = cnt
                 break
         self.assertTrue(plugin_index >= 0, "Image plugin not activated")
-        base_edit_url = reverse('wiki:edit', kwargs={'path': ''})
+        base_edit_url = reverse('wiki:edit', kwargs={'path': path})
         url = base_edit_url + '?f=form{0:d}'.format(plugin_index)
         filestream = self._create_gif_filestream_from_base64(self.test_data)
         response = self.c.post(
@@ -76,7 +77,7 @@ class ImageTests(ArticleWebTestBase):
         Uploading a file should preserve the original filename.
         Uploading should not modify file in any way.
         """
-        self._create_test_image()
+        self._create_test_image('')
         # Check the object was created.
         image = models.Image.objects.get()
         image_revision = image.current_revision.imagerevision
@@ -85,3 +86,46 @@ class ImageTests(ArticleWebTestBase):
             image_revision.image.file.read(),
             base64.b64decode(self.test_data)
         )
+
+    def get_article(self, cont, image):
+        urlpath = URLPath.create_article(URLPath.root(),
+                                      "html_image",
+                                      title="TestImage",
+                                      content=cont)
+        if (image):
+            self._create_test_image(urlpath.path)
+        return urlpath.article.render()
+
+    def test_image_missing(self):
+        output = self.get_article("[image:1]", False)
+        expected = ( '<figure class="thumbnail"><a href="">'
+                     '<div class="caption"><em>Image not found</em></div>'
+                     '</a><figcaption class="caption"></figcaption></figure>' )
+        self.assertEqual(output, expected)
+
+    def test_image_default(self):
+        output = self.get_article("[image:1]", True)
+        image_rev = models.Image.objects.get().current_revision.imagerevision
+        expected = ( '<figure class="thumbnail">'
+                     '<a href="' + image_rev.image.name + '">'
+                     '<img alt="test\.gif" src="cache/.*\.jpg">'
+                     '</a><figcaption class="caption"></figcaption></figure>' )
+        self.assertRegex(output, expected)
+
+    def test_image_large_right(self):
+        output = self.get_article("[image:1 align:right size:large]", True)
+        image_rev = models.Image.objects.get().current_revision.imagerevision
+        expected = ( '<figure class="thumbnail pull-right">'
+                     '<a href="' + image_rev.image.name + '">'
+                     '<img alt="test\.gif" src="cache/.*\.jpg"></a>'
+                     '<figcaption class="caption"></figcaption></figure>' )
+        self.assertRegex(output, expected)
+
+    def test_image_orig(self):
+        output = self.get_article("[image:1 size:orig]", True)
+        image_rev = models.Image.objects.get().current_revision.imagerevision
+        expected = ( '<figure class="thumbnail">'
+                     '<a href="' + image_rev.image.name + '">'
+                     '<img alt="test.gif" src="' + image_rev.image.name + '"></a>'
+                     '<figcaption class="caption"></figcaption></figure>' )
+        self.assertEqual(output, expected)


### PR DESCRIPTION
Added a new option to specify the thumbnail size of images.
This patch is based on the work by inflrscns:

    https://github.com/django-wiki/django-wiki/compare/master...inflrscns:thumbnail-sizes

Extensions compared to that version are:
  - New image size "orig". No thumbnail is generated in this case, but the original image is shown instead.
  - Updated image help in the sidebar.

The size can be specified by "size:small | medium | large | orig | default".
The small/medium/large/default sizes are configurable.
