### PR TITLE
Allow the HTML tag <br>.

### DIFF
--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -41,6 +41,7 @@ MARKDOWN_KWARGS.update(getattr(django_settings, 'WIKI_MARKDOWN_KWARGS', {}))
 _default_tag_whitelists = bleach.ALLOWED_TAGS + [
     'figure',
     'figcaption',
+    'br',
     'p',
     'div',
     'img',


### PR DESCRIPTION
When adding two spaces at the end of lines markdown creates a \<br\> tag.
\<br\> needs to be allowed for that.