### PR TITLE
Fixes issue where Markdown extension crashes when an absolute URL is used in a wiki link.

### DIFF
--- a/requirements_readthedocs.txt
+++ b/requirements_readthedocs.txt
@@ -1,7 +1,7 @@
 # This is because readthedocs has an old version of pip
 # that somehow doesn't like prerelease versions in the
 # dependency expressions (>=1.0b1 failes to find dist)
-Django>=1.8
+Django>=1.8,<1.11
 Pillow
 django-nyt>=1.0b1
 six

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read_file(fname):
 
 
 requirements = [
-    "Django>=1.8",
+    "Django>=1.8,<1.11",
     "bleach>=1.5,<2",
     "Pillow",
     "django-nyt>=1.0b1",

--- a/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/wiki/plugins/links/mdx/djangowikilinks.py
@@ -51,7 +51,6 @@ class WikiPathExtension(markdown.Extension):
 
         # Override defaults with user settings
         for key, value in configs:
-            # self.config[key][0] = value
             self.setConfig(key, value)
 
     def extendMarkdown(self, md, md_globals):
@@ -84,7 +83,7 @@ class WikiPath(markdown.inlinepatterns.Pattern):
 
         if absolute:
             base_path = self.config['base_url'][0]
-            path_from_link = os_path.join(base_path, article_title)
+            path_from_link = os_path.join(str(base_path), article_title)
 
             urlpath = None
             path = path_from_link

--- a/wiki/tests/test_markdown_plugins.py
+++ b/wiki/tests/test_markdown_plugins.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+import markdown
+from django.test import TestCase
+from django.core.urlresolvers import reverse_lazy
+from wiki.plugins.links.mdx.djangowikilinks import WikiPathExtension
+from wiki.models import URLPath
+
+
+class WikiPathExtensionTests(TestCase):
+    def test_works_with_lazy_functions(self):
+        URLPath.create_root()
+        config = (
+            ('base_url', reverse_lazy('wiki:get', kwargs={'path': ''})),
+        )
+        md = markdown.Markdown(
+            extensions=['extra', WikiPathExtension(config)]
+        )
+        text = '[Français](wiki:/fr)'
+        self.assertEqual(
+            md.convert(text),
+            '<p><a class="wikipath linknotfound" href="/fr">Français</a></p>',
+        )


### PR DESCRIPTION
A URL like this one: `[Français](wiki:/fr)` seems to be crashing. The `config['base_url']` seems to be a Proxy object (See here: https://github.com/django-wiki/django-wiki/blob/master/wiki/plugins/links/wiki_plugin.py#L30) and when the wiki link is absolute, it crashes with a traceback like this:

![image](https://cloud.githubusercontent.com/assets/165929/25060015/233f3d00-2160-11e7-8f9c-05299c331646.png)

This PR does the following:

1. Adds a test case to replicate the bug.
2. Fixes the bug by evaluating the lazy object

In addition I'm adding `,<1.11` to `setup.py` and requirements file because django-wiki doesn't currently support Django 1.11.

Useful part of the traceback:

```python
File "/home/b/projects/django-wiki/wiki/models/article.py" in render
  209.                                           preview=preview_content is not None))

File "/home/b/projects/django-wiki/wiki/core/markdown/__init__.py" in article_markdown
  49.     return md.convert(text)

File "/home/b/projects/django-wiki/wiki/core/markdown/__init__.py" in convert
  37.         html = super(ArticleMarkdown, self).convert(text, *args, **kwargs)

File "/home/b/.pyenv/versions/3.6.1/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/__init__.py" in convert
  375.             newRoot = treeprocessor.run(root)

File "/home/b/.pyenv/versions/3.6.1/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/treeprocessors.py" in run
  295.                         self.__handleInline(text), child

File "/home/b/.pyenv/versions/3.6.1/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/treeprocessors.py" in __handleInline
  106.                     data, patternIndex, startIndex)

File "/home/b/.pyenv/versions/3.6.1/lib/python3.6/site-packages/Markdown-2.6.8-py3.6.egg/markdown/treeprocessors.py" in __applyPattern
  239.         node = pattern.handleMatch(match)

File "/home/b/projects/django-wiki/wiki/plugins/links/mdx/djangowikilinks.py" in handleMatch
  86.             path_from_link = os_path.join(base_path, article_title)

File "/home/b/.pyenv/versions/3.6.1/lib/python3.6/posixpath.py" in join
  78.     a = os.fspath(a)

Exception Type: TypeError at /
Exception Value: expected str, bytes or os.PathLike object, not __proxy__
```