### PR TITLE
Add support for Github flavored fenced code blocks

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,6 +16,7 @@ django-wiki 0.2.3 (unreleased)
 
  * Pulled Transifex translations and pushed source translations.
  * Fix support for Py2 unicode in code blocks (Benjamin Bach) #607
+ * Support for Github style fenced codeblocks (Benjamin Bach) #618
 
 
 django-wiki 0.2.2

--- a/wiki/core/markdown/mdx/codehilite.py
+++ b/wiki/core/markdown/mdx/codehilite.py
@@ -68,14 +68,6 @@ class WikiFencedBlockPreprocessor(Preprocessor):
                 break
         return text.split("\n")
 
-    def _escape(self, txt):
-        """ basic html escaping """
-        txt = txt.replace('&', '&amp;')
-        txt = txt.replace('<', '&lt;')
-        txt = txt.replace('>', '&gt;')
-        txt = txt.replace('"', '&quot;')
-        return txt
-
 
 class HiliteTreeprocessor(Treeprocessor):
     """ Hilight source code in code blocks. """

--- a/wiki/core/markdown/mdx/codehilite.py
+++ b/wiki/core/markdown/mdx/codehilite.py
@@ -1,11 +1,80 @@
 from __future__ import unicode_literals
 
 import logging
+import re
 
 from markdown.extensions.codehilite import CodeHilite, CodeHiliteExtension
+from markdown.preprocessors import Preprocessor
 from markdown.treeprocessors import Treeprocessor
 
 logger = logging.getLogger(__name__)
+
+
+def highlight(code, config, tab_length, lang=None):
+    code = CodeHilite(
+        code,
+        linenums=config['linenums'],
+        guess_lang=config['guess_lang'],
+        css_class=config['css_class'],
+        style=config['pygments_style'],
+        noclasses=config['noclasses'],
+        tab_length=tab_length,
+        use_pygments=config['use_pygments'],
+        lang=lang,
+    )
+    html = code.hilite()
+    html = """<div class="codehilite-wrap">{}</div>""".format(html)
+    return html
+
+
+class WikiFencedBlockPreprocessor(Preprocessor):
+    """
+    This is a replacement of markdown.extensions.fenced_code which will
+    directly and without configuration options invoke the vanilla CodeHilite
+    extension.
+    """
+    FENCED_BLOCK_RE = re.compile(r'''
+(?P<fence>^(?:~{3,}|`{3,}))[ ]*         # Opening ``` or ~~~
+(\{?\.?(?P<lang>[a-zA-Z0-9_+-]*))?[ ]*  # Optional {, and lang
+# Optional highlight lines, single- or double-quote-delimited
+(hl_lines=(?P<quot>"|')(?P<hl_lines>.*?)(?P=quot))?[ ]*
+}?[ ]*\n                                # Optional closing }
+(?P<code>.*?)(?<=\n)
+(?P=fence)[ ]*$''', re.MULTILINE | re.DOTALL | re.VERBOSE)
+    CODE_WRAP = '<pre>%s</pre>'
+
+    def __init__(self, md):
+        super(WikiFencedBlockPreprocessor, self).__init__(md)
+
+        self.checked_for_codehilite = False
+        self.codehilite_conf = {}
+
+    def run(self, lines):
+        """ Match and store Fenced Code Blocks in the HtmlStash. """
+
+        text = "\n".join(lines)
+        while 1:
+            m = self.FENCED_BLOCK_RE.search(text)
+            if m:
+                lang = ''
+                if m.group('lang'):
+                    lang = m.group('lang')
+                html = highlight(m.group('code'), self.config, self.markdown.tab_length, lang=lang)
+                placeholder = self.markdown.htmlStash.store(html, safe=True)
+                text = '%s\n%s\n%s' % (text[:m.start()],
+                                       placeholder,
+                                       text[m.end():])
+            else:
+                break
+        return text.split("\n")
+
+    def _escape(self, txt):
+        """ basic html escaping """
+        txt = txt.replace('&', '&amp;')
+        txt = txt.replace('<', '&lt;')
+        txt = txt.replace('>', '&gt;')
+        txt = txt.replace('"', '&quot;')
+        return txt
 
 
 class HiliteTreeprocessor(Treeprocessor):
@@ -16,18 +85,7 @@ class HiliteTreeprocessor(Treeprocessor):
         blocks = root.iter('pre')
         for block in blocks:
             if len(block) == 1 and block[0].tag == 'code':
-                code = CodeHilite(
-                    block[0].text,
-                    linenums=self.config['linenums'],
-                    guess_lang=self.config['guess_lang'],
-                    css_class=self.config['css_class'],
-                    style=self.config['pygments_style'],
-                    noclasses=self.config['noclasses'],
-                    tab_length=self.markdown.tab_length,
-                    use_pygments=self.config['use_pygments']
-                )
-                html = code.hilite()
-                html = """<div class="codehilite-wrap">{}</div>""".format(html)
+                html = highlight(block[0].text, self.config, self.markdown.tab_length)
                 placeholder = self.markdown.htmlStash.store(html, safe=True)
                 # Clear codeblock in etree instance
                 block.clear()
@@ -55,5 +113,17 @@ class WikiCodeHiliteExtension(CodeHiliteExtension):
             )
             del md.treeprocessors["hilite"]
         md.treeprocessors.add("hilite", hiliter, "<inline")
+
+        if "fenced_code_block" in md.preprocessors:
+            logger.warning(
+                "Replacing existing 'fenced_code_block' extension - please remove "
+                "'fenced_code_block' or 'extras' from WIKI_MARKDOWN_KWARGS"
+            )
+            del md.preprocessors["fenced_code_block"]
+        hiliter = WikiFencedBlockPreprocessor(md)
+        hiliter.config = self.getConfigs()
+        md.preprocessors.add('fenced_code_block',
+                             hiliter,
+                             ">normalize_whitespace")
 
         md.registerExtension(self)

--- a/wiki/tests/test_markdown_plugins.py
+++ b/wiki/tests/test_markdown_plugins.py
@@ -65,13 +65,13 @@ class CodehiliteTests(TestCase):
         )
         result = (
             """<p>Code:</p>\n"""
-            """<div class="codehilite-wrap"><div class="codehilite"><pre><span></span>echo &#39;line 1&#39;\n"""
-            """echo &#39;line 2&#39;\n"""
+            """<div class="codehilite-wrap"><div class="codehilite"><pre><span></span><span class="n">echo</span> <span class="s1">&#39;line 1&#39;</span>\n"""
+            """<span class="n">echo</span> <span class="s1">&#39;line 2&#39;</span>\n"""
             """</pre></div>\n"""
             """</div>"""
         ) if pygments else (
             """<p>Code:</p>\n"""
-            """<div class="codehilite-wrap"><pre class="codehilite"><code>echo 'line 1'\n"""
+            """<div class="codehilite-wrap"><pre class="codehilite"><code class="language-python">echo 'line 1'\n"""
             """echo 'line 2'</code></pre>\n"""
             """</div>"""
         )

--- a/wiki/tests/test_markdown_plugins.py
+++ b/wiki/tests/test_markdown_plugins.py
@@ -51,32 +51,7 @@ class ResponsiveTableExtensionTests(TestCase):
 
 class CodehiliteTests(TestCase):
 
-    def test_simple_code(self):
-        md = markdown.Markdown(
-            extensions=['extra', WikiCodeHiliteExtension()]
-        )
-        text = (
-            "Code:\n"
-            "\n"
-            "```\n"
-            "echo 'hello æøå'\n"
-            "```\n"
-        )
-        result = (
-            """<p>Code:</p>\n"""
-            """<div class="codehilite"><pre><span></span>echo &#39;hello æøå&#39;\n"""
-            """</pre></div>"""
-        ) if pygments else (
-            """<p>Code:</p>\n"""
-            """<pre class="codehilite"><code>echo 'hello æøå'</code></pre>"""
-        )
-        self.assertEqual(
-            md.convert(text),
-            result
-        )
-
-
-    def test_advanced_code(self):
+    def test_fenced_code(self):
         md = markdown.Markdown(
             extensions=['extra', WikiCodeHiliteExtension()]
         )
@@ -90,20 +65,22 @@ class CodehiliteTests(TestCase):
         )
         result = (
             """<p>Code:</p>\n"""
-            """<div class="codehilite"><pre><span></span><span class="n">echo</span> <span class="s1">&#39;line 1&#39;</span>\n"""
-            """<span class="n">echo</span> <span class="s1">&#39;line 2&#39;</span>\n"""
-            """</pre></div>"""
+            """<div class="codehilite-wrap"><div class="codehilite"><pre><span></span>echo &#39;line 1&#39;\n"""
+            """echo &#39;line 2&#39;\n"""
+            """</pre></div>\n"""
+            """</div>"""
         ) if pygments else (
             """<p>Code:</p>\n"""
-            """<pre class="codehilite"><code class="language-python">echo 'line 1'\n"""
-            """echo 'line 2'</code></pre>"""
+            """<div class="codehilite-wrap"><pre class="codehilite"><code>echo 'line 1'\n"""
+            """echo 'line 2'</code></pre>\n"""
+            """</div>"""
         )
         self.assertEqual(
             md.convert(text),
             result,
         )
 
-    def test_advanced_code2(self):
+    def test_indented_code(self):
         md = markdown.Markdown(
             extensions=['extra', WikiCodeHiliteExtension()]
         )


### PR DESCRIPTION
Example:

    ```python
    print("This will be highlighted")
    ```
