### PR TITLE
Setting `WIKI_MARKDOWN_HTML_STYLES` for allowing styles in user html

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -20,6 +20,7 @@ django-wiki 0.2.3 (unreleased)
  * Cached articles showing up in wrong language (Benjamin Bach) #592
  * Upgraded Bootstrap from 3.3.1 to 3.3.7 (Benjamin Bach) #620
  * Upgraded bundled jQuery to 1.12.4 (Benjamin Bach) #620
+ * Setting ``WIKI_MARKDOWN_HTML_STYLES`` for allowing ``style='..'`` in user code (Benjamin Bach) #603
 
 
 django-wiki 0.2.2

--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -93,6 +93,25 @@ MARKDOWN_HTML_ATTRIBUTES.update(
     )
 )
 
+# Allowed inline styles, default is no styles (empty list)
+MARKDOWN_HTML_STYLES = (
+    getattr(
+        django_settings,
+        'WIKI_MARKDOWN_HTML_STYLES',
+        []
+    )
+)
+
+_project_defined_attrs = getattr(
+    django_settings,
+    'WIKI_MARKDOWN_HTML_ATTRIBUTE_WHITELIST',
+    False)
+
+# If styles are allowed but no custom attributes are defined, we allow styles
+# for all kinds of tags
+if MARKDOWN_HTML_STYLES and not _project_defined_attrs:
+    MARKDOWN_HTML_ATTRIBUTES['*'] = 'style'
+
 
 # This slug is used in URLPath if an article has been deleted. The children of the
 # URLPath of that article are moved to lost and found. They keep their permissions

--- a/wiki/core/markdown/__init__.py
+++ b/wiki/core/markdown/__init__.py
@@ -40,6 +40,7 @@ class ArticleMarkdown(markdown.Markdown):
                 html,
                 tags=settings.MARKDOWN_HTML_WHITELIST,
                 attributes=settings.MARKDOWN_HTML_ATTRIBUTES,
+                styles=settings.MARKDOWN_HTML_STYLES,
             )
         return html
 


### PR DESCRIPTION
Fixes #603

See: http://bleach.readthedocs.io/en/latest/clean.html#allowed-styles-styles