### PR TITLE
Adds a functional test for the TOC plugin

### DIFF
--- a/wiki/tests/test_markdown_plugins.py
+++ b/wiki/tests/test_markdown_plugins.py
@@ -9,6 +9,7 @@ from wiki.core.markdown.mdx.codehilite import WikiCodeHiliteExtension
 from wiki.core.markdown.mdx.responsivetable import ResponsiveTableExtension
 from wiki.models import URLPath
 from wiki.plugins.links.mdx.djangowikilinks import WikiPathExtension
+from wiki.plugins.macros.mdx.toc import WikiTocExtension
 
 
 try:
@@ -116,3 +117,38 @@ class CodehiliteTests(TestCase):
             md.convert(text),
             result,
         )
+
+
+class TocMacroTests(TestCase):
+    def test_toc_renders_table_of_content(self):
+        """ Verifies that the [TOC] wiki code renders a Table of Content
+        """
+        md = markdown.Markdown(
+            extensions=['extra', WikiTocExtension()]
+        )
+        text = (
+            "[TOC]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc">\n'
+            '<ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            '</ul>\n'
+            '</li>\n'
+            '</ul>\n'
+            '</div>\n'
+            '<h1 id="wiki-toc-first-title">First title.</h1>\n'
+            '<p>Paragraph 1</p>\n'
+            '<h2 id="wiki-toc-subsection">Subsection</h2>\n'
+            '<p>Paragraph 2</p>'
+        )
+        self.assertEqual(md.convert(text), expected_output)


### PR DESCRIPTION
Just adding a test for TOC. I think the TOC codepath is already executed in some of the tests, but this adds a TOC-specific content assertion.

I want to add a horizontal TOC markdown plugin so I need to starts with some basic tests.

ping @benjaoming 