### PR TITLE
Allow the HTML tag <hr>.

### DIFF
--- a/wiki/conf/settings.py
+++ b/wiki/conf/settings.py
@@ -56,6 +56,7 @@ _default_tag_whitelists = bleach.ALLOWED_TAGS + [
     'figure',
     'figcaption',
     'br',
+    'hr',
     'p',
     'div',
     'img',


### PR DESCRIPTION
When placing three hyphens, asterisks, or underscores on a line by
themselves markdown creates a \<hr\> tag. \<hr\> needs to be allowed
for that.
