### PR TITLE
Django 1.11 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,15 @@ env:
 - TOXENV=py27-django18
 - TOXENV=py27-django19
 - TOXENV=py27-django110
+- TOXENV=py27-django111
 - TOXENV=py34-django18
 - TOXENV=py34-django19
 - TOXENV=py34-django110
+- TOXENV=py34-django111
 - TOXENV=py35-django18
 - TOXENV=py35-django19
 - TOXENV=py35-django110
+- TOXENV=py35-django111
 
 install:
   - pip install tox>=2.1 coveralls

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include COPYING
 include README.rst
 include setup.cfg
+include runtests.py
 recursive-include src *.html *.txt *.png *.js *.css *.gif *.less *.mo *.po *.otf *.svg *.woff *.woff2 *.eot *.ttf
 prune src/wiki/attachments
 prune src/wiki/images

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint:  ## Check python code conventions
 	pep8 src/wiki
 
 test:  ## Run automated test suite
-	pytest
+	./runtests.py
 
 test-all:  ## Run tests on all supported Python environments
 	tox

--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,22 @@ issue to discuss whether your plugin idea is a core plugin
 (``wiki.plugins.*``) or external plugin. If there are additions needed
 to the plugin API, we can discuss that as well!
 
-To run django-wiki's tests, run ``make test``
-after installing the requirements.
+To run django-wiki's tests:
+
+* Checkout this repo from Github, ``cd`` into it.
+* Create and activate a virtualenv for developing django-wiki.
+  Ensure you are using recent setuptools and pip.
+* Install the requirements::
+
+    $ pip install --upgrade pip setuptools
+    $ ./setup.py develop
+    $ pip install pytest pytest-django pytest-cov mock
+
+* Add the current directory to your virtualenv path so that tests can be found::
+
+    $ pwd >> $VIRTUAL_ENV/lib/python2.7/site-packages/easy-install.pth
+
+* Run ``make test``
 
 If you want to test for more **environments**, install "tox"
 (``pip install tox``) and then just run ``tox`` to run the test

--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,10 @@ suite on multiple environments.
 
 To run **specific tests**, see ``./runtests.py --help``.
 
+To include Selenium tests, you need to install `chromedriver
+<https://sites.google.com/a/chromium.org/chromedriver/>`_ and run
+``./runtests.py --include-selenium``
+
 Manifesto
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,9 @@ To run **specific tests**, see ``./runtests.py --help``.
 
 To include Selenium tests, you need to install `chromedriver
 <https://sites.google.com/a/chromium.org/chromedriver/>`_ and run
-``./runtests.py --include-selenium``
+``./runtests.py --include-selenium``. For tox, do::
+
+    INCLUDE_SELENIUM_TESTS=1 tox
 
 Manifesto
 ---------

--- a/README.rst
+++ b/README.rst
@@ -121,14 +121,13 @@ To run django-wiki's tests:
 
     $ pwd >> $VIRTUAL_ENV/lib/python2.7/site-packages/easy-install.pth
 
-* Run ``make test``
+* Run ``make test`` or ``./runtests.py``
 
 If you want to test for more **environments**, install "tox"
 (``pip install tox``) and then just run ``tox`` to run the test
 suite on multiple environments.
 
-To run **specific tests**, call ``pytest`` with a path to the file with
-the tests you wish to run, for instance ``pytest wiki/tests/test_views.py``.
+To run **specific tests**, see ``./runtests.py --help``.
 
 Manifesto
 ---------

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,35 @@ the project without tests wouldn't be fair to the project or
 your hard work. We use coverage metrics to see that each new
 contribution does not significantly impact test coverage.
 
+Tests generally fall into a few categories:
+
+* Testing at the model level. These test cases should inherit from
+  ``tests.base.TestBase``.
+
+* Tests for views that return HTML. We normally use `django-functest
+  <http://django-functest.readthedocs.io/en/latest/>`_ for these, especially if
+  the page involves forms and handling of POST data. Test cases should inherit
+  from ``tests.base.WebTestBase`` and ``tests.base.SeleniumBase`` - see
+  ``tests.core.test_views.RootArticleViewTestsBase``,
+  ``RootArticleViewTestsWebTest`` and ``RootArticleViewTestsSelenium`` for an
+  example.
+
+  Views should be written so that as far as possible they work without
+  Javascript, and can be tested using the fast WebTest method, rather than
+  relying on the slow and fragile Selenium method. Selenium tests are not run by
+  default.
+
+  (In the past the Django test Client was used for these, and currently there
+  are still a lot of tests written in this style. These should be gradually
+  phased out where possible, because the test Client does a poor job of
+  replicating what browsers and people actually do.
+
+* Tests for views that return JSON or other non-HTML. These test cases
+  should inherit from ``tests.base.DjangoClientTestBase``.
+
+There are also other mixins in ``tests.base`` that provide commonly used
+fixtures for tests e.g. a root article.
+
 The easiest way to add features is to write a plugin. Please create an
 issue to discuss whether your plugin idea is a core plugin
 (``wiki.plugins.*``) or external plugin. If there are additions needed

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ To run django-wiki's tests:
 
     $ pip install --upgrade pip setuptools
     $ ./setup.py develop
-    $ pip install pytest pytest-django pytest-cov mock
+    $ pip install pytest pytest-django pytest-cov mock django-functest
 
 * Add the current directory to your virtualenv path so that tests can be found::
 

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+from __future__ import print_function, unicode_literals
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+
+
+class RuntestsArgumentParser(argparse.ArgumentParser):
+    def print_help(self):
+        super(RuntestsArgumentParser, self).print_help()
+        print("\n")
+        print("All other arguments will be passed to pytest, \n"
+              "which has the following options:\n")
+        subprocess.call(["pytest", "--help"])
+
+parser = RuntestsArgumentParser(usage="./runtests.py [args] [tests to run]\n\n"
+                                "Individual tests can be run using pytest syntax e.g.\n\n"
+                                "  ./runtests.py ./tests/core/test_views.py::ArticleViewViewTests::test_article_list_update\n")
+parser.add_argument("--include-selenium", action='store_true',
+                    help="Include Selenium tests, which are skipped by default")
+
+
+def main():
+    known_args, remaining_args = parser.parse_known_args()
+    cmd = ["pytest"] + remaining_args
+    if known_args.include_selenium:
+        # It is easier to use environment variables than to use 'pytest -k',
+        # because the user might want to use that option.
+        os.environ['INCLUDE_SELENIUM_TESTS'] = "1"
+
+    # Signal handling to ensure the right thing happens
+    # when Ctrl-C is pressed.
+    SIGINT_RECEIVED = False
+
+    def signal_handler(sig, f):
+        global SIGINT_RECEIVED
+        SIGINT_RECEIVED = True
+        # No other action, just allow child to exit.
+
+
+    signal.signal(signal.SIGINT, signal_handler)
+
+    retcode = subprocess.call(cmd)
+
+    if SIGINT_RECEIVED:
+        sys.exit(1)
+    else:
+        sys.exit(retcode)
+
+if __name__ == '__main__':
+    main()

--- a/runtests.py
+++ b/runtests.py
@@ -21,6 +21,8 @@ parser = RuntestsArgumentParser(usage="./runtests.py [args] [tests to run]\n\n"
                                 "  ./runtests.py ./tests/core/test_views.py::ArticleViewViewTests::test_article_list_update\n")
 parser.add_argument("--include-selenium", action='store_true',
                     help="Include Selenium tests, which are skipped by default")
+parser.add_argument("--show-browser", action='store_true',
+                    help="Show browser window when running Selenium tests")
 
 
 def main():
@@ -30,6 +32,8 @@ def main():
         # It is easier to use environment variables than to use 'pytest -k',
         # because the user might want to use that option.
         os.environ['INCLUDE_SELENIUM_TESTS'] = "1"
+    if known_args.show_browser:
+        os.environ['SELENIUM_SHOW_BROWSER'] = "1"
 
     # Signal handling to ensure the right thing happens
     # when Ctrl-C is pressed.

--- a/runtests.py
+++ b/runtests.py
@@ -20,7 +20,7 @@ parser = RuntestsArgumentParser(usage="./runtests.py [args] [tests to run]\n\n"
                                 "Individual tests can be run using pytest syntax e.g.\n\n"
                                 "  ./runtests.py ./tests/core/test_views.py::ArticleViewViewTests::test_article_list_update\n")
 parser.add_argument("--include-selenium", action='store_true',
-                    help="Include Selenium tests, which are skipped by default")
+                    help="Include Selenium tests, which are skipped by default. Requires chromedriver")
 parser.add_argument("--show-browser", action='store_true',
                     help="Show browser window when running Selenium tests")
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read_file(fname):
 
 
 requirements = [
-    "Django>=1.8,<1.11",
+    "Django>=1.8,<1.12",
     "bleach>=1.5,<2",
     "Pillow",
     "django-nyt>=1.0b1",

--- a/src/wiki/core/compat.py
+++ b/src/wiki/core/compat.py
@@ -27,3 +27,19 @@ try:
 except AttributeError:
     atomic = nop_decorator
     transaction_commit_on_success = transaction.commit_on_success
+
+
+# Django 1.11 Widget.build_attrs has a different signature, designed for the new
+# template based rendering. The previous version was more useful for our needs,
+# so we restore that version.
+# When support for Django < 1.11 is dropped, we should look at using the
+# new template based rendering, at which point this probably won't be needed at all.
+class BuildAttrsCompat(object):
+    def build_attrs_compat(self, extra_attrs=None, **kwargs):
+        "Helper function for building an attribute dictionary."
+        attrs = self.attrs.copy()
+        if extra_attrs is not None:
+            attrs.update(extra_attrs)
+        if kwargs is not None:
+            attrs.update(kwargs)
+        return attrs

--- a/src/wiki/editors/markitup.py
+++ b/src/wiki/editors/markitup.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from django import forms
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
+from wiki.core.compat import BuildAttrsCompat
 from wiki.editors.base import BaseEditor
 
 # Due to deprecation of django.forms.util in Django 1.9
@@ -20,9 +21,7 @@ except ImportError:
         return(x)
 
 
-
-
-class MarkItUpAdminWidget(forms.Widget):
+class MarkItUpAdminWidget(BuildAttrsCompat, forms.Widget):
 
     """A simplified more fail-safe widget for the backend"""
 
@@ -37,7 +36,7 @@ class MarkItUpAdminWidget(forms.Widget):
     def render(self, name, value, attrs=None):
         if value is None:
             value = ''
-        final_attrs = self.build_attrs(attrs, name=name)
+        final_attrs = self.build_attrs_compat(attrs, name=name)
         return mark_safe(
             '<textarea%s>%s</textarea>' %
             (flatatt(final_attrs),
@@ -45,7 +44,7 @@ class MarkItUpAdminWidget(forms.Widget):
                 force_unicode(value))))
 
 
-class MarkItUpWidget(forms.Widget):
+class MarkItUpWidget(BuildAttrsCompat, forms.Widget):
 
     def __init__(self, attrs=None):
         # The 'rows' and 'cols' attributes are required for HTML correctness.
@@ -58,7 +57,7 @@ class MarkItUpWidget(forms.Widget):
     def render(self, name, value, attrs=None):
         if value is None:
             value = ''
-        final_attrs = self.build_attrs(attrs, name=name)
+        final_attrs = self.build_attrs_compat(attrs, name=name)
         return mark_safe(
             '<div><textarea%s>%s</textarea></div>' %
             (flatatt(final_attrs),

--- a/src/wiki/forms.py
+++ b/src/wiki/forms.py
@@ -22,7 +22,7 @@ from six.moves import range
 from wiki import models
 from wiki.conf import settings
 from wiki.core import permissions
-from wiki.core.compat import get_user_model
+from wiki.core.compat import get_user_model, BuildAttrsCompat
 from wiki.core.diff import simple_merge
 from wiki.core.plugins.base import PluginSettingsFormMixin
 from wiki.editors import getEditor
@@ -243,8 +243,7 @@ class EditForm(forms.Form, SpamProtectionMixin):
         return cd
 
 
-class SelectWidgetBootstrap(forms.Select):
-
+class SelectWidgetBootstrap(BuildAttrsCompat, forms.Select):
     """
     http://twitter.github.com/bootstrap/components.html#buttonDropdowns
     Needs bootstrap and jquery
@@ -264,7 +263,7 @@ class SelectWidgetBootstrap(forms.Select):
     def render(self, name, value, attrs=None, choices=()):
         if value is None:
             value = ''
-        final_attrs = self.build_attrs(attrs, name=name)
+        final_attrs = self.build_attrs_compat(attrs, name=name)
         output = [
             """<div%(attrs)s>"""
             """    <button class="btn btn-group-label%(disabled)s" type="button">%(label)s</button>"""

--- a/src/wiki/templates/wiki/edit.html
+++ b/src/wiki/templates/wiki/edit.html
@@ -25,7 +25,10 @@
       <div class="form-group form-actions">
         <div class="col-lg-8">
           <div class="col-lg-offset-2">
-            <button class="btn btn-default" onclick="$('#previewModal').modal('show'); document.getElementById('article_edit_form').target='previewWindow'; document.getElementById('article_edit_form').action='{% url 'wiki:preview' path=urlpath.path article_id=article.id %}'; $('#article_edit_form').submit()" type="submit">
+            <button class="btn btn-default" type="submit" name="preview" value="1" id="id_preview"
+                    formaction="{% url 'wiki:preview' path=urlpath.path article_id=article.id %}"
+                    formtarget="previewWindow"
+                    >
               <span class="fa fa-eye"></span>
               {% trans "Preview" %}
             </button>
@@ -68,7 +71,7 @@
           <span class="fa fa-arrow-circle-left"></span>
           {% trans "Back to editor" %}
         </a>
-        <a class="btn btn-lg btn-primary" onclick="window.onbeforeunload = null; document.getElementById('article_edit_form').target=''; document.getElementById('article_edit_form').action='{% url 'wiki:edit' path=urlpath.path article_id=article.id %}'; document.getElementById('article_edit_form').submit();" href="#">
+        <a class="btn btn-lg btn-primary" id="id_preview_save_changes" href="#">
           <span class="fa fa-check"></span>
           {% trans "Save changes" %}
         </a>
@@ -91,7 +94,15 @@
     $("#article_edit_form").on("submit", function () {
         window.onbeforeunload = null;
         return true;
-    })
+    });
+    $("#id_preview").on("click", function () {
+        $("#previewModal").modal("show");
+        return true;
+    });
+    $("#id_preview_save_changes").on("click", function (ev) {
+        ev.preventDefault();
+        $("#id_save").trigger("click");
+    });
   });
 
 var confirmOnPageExit = function (e) {

--- a/src/wiki/templates/wiki/edit.html
+++ b/src/wiki/templates/wiki/edit.html
@@ -17,11 +17,32 @@
 
   <div class="col-lg-8">
     <form method="POST" class="form-horizontal" id="article_edit_form">
-      <input type="hidden" name="save" value="1" />
       <input type="hidden" name="preview" value="1" />
       {% with edit_form as form %}
         {% include "wiki/includes/editor.html" %}
       {% endwith %}
+
+      <div class="form-group form-actions">
+        <div class="col-lg-8">
+          <div class="col-lg-offset-2">
+            <button class="btn btn-default" onclick="$('#previewModal').modal('show'); document.getElementById('article_edit_form').target='previewWindow'; document.getElementById('article_edit_form').action='{% url 'wiki:preview' path=urlpath.path article_id=article.id %}'; $('#article_edit_form').submit()" type="submit">
+              <span class="fa fa-eye"></span>
+              {% trans "Preview" %}
+            </button>
+            <button class="btn btn-primary" type="submit" name="save" value="1" id="id_save">
+              <span class="fa fa-check"></span>
+              {% trans "Save changes" %}
+            </button>
+            {% if article|can_delete:user %}
+              <a href="{% url 'wiki:delete' path=urlpath.path article_id=article.id %}" class="btn btn-danger pull-right">
+                <span class="fa fa-trash-o"></span>
+                {% trans "Delete article" %}
+              </a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
     </form>
   </div>
 
@@ -33,26 +54,6 @@
 
 <div style="clear: both"></div>
 
-<div class="form-group form-actions">
-  <div class="col-lg-8">
-    <div class="col-lg-offset-2">
-      <a class="btn btn-default" onclick="$('#previewModal').modal('show'); document.getElementById('article_edit_form').target='previewWindow'; document.getElementById('article_edit_form').action='{% url 'wiki:preview' path=urlpath.path article_id=article.id %}'; $('#article_edit_form').submit()" href="#">
-        <span class="fa fa-eye"></span>
-        {% trans "Preview" %}
-      </a>
-      <a class="btn btn-primary" onclick="window.onbeforeunload = null; document.getElementById('article_edit_form').target=''; document.getElementById('article_edit_form').action='{% url 'wiki:edit' path=urlpath.path article_id=article.id %}'; $('#article_edit_form').submit();" href="#">
-        <span class="fa fa-check"></span>
-        {% trans "Save changes" %}
-      </a>
-      {% if article|can_delete:user %}
-      <a href="{% url 'wiki:delete' path=urlpath.path article_id=article.id %}" class="btn btn-danger pull-right">
-        <span class="fa fa-trash-o"></span>
-        {% trans "Delete article" %}
-      </a>
-      {% endif %}
-    </div>
-  </div>
-</div>
 
 {% include "wiki/includes/modals.html" %}
 
@@ -87,6 +88,10 @@
       $("#article_edit_form").data("changed",true);
     }
     window.onbeforeunload = confirmOnPageExit;
+    $("#article_edit_form").on("submit", function () {
+        window.onbeforeunload = null;
+        return true;
+    })
   });
 
 var confirmOnPageExit = function (e) {

--- a/src/wiki/templates/wiki/edit.html
+++ b/src/wiki/templates/wiki/edit.html
@@ -17,7 +17,6 @@
 
   <div class="col-lg-8">
     <form method="POST" class="form-horizontal" id="article_edit_form">
-      <input type="hidden" name="preview" value="1" />
       {% with edit_form as form %}
         {% include "wiki/includes/editor.html" %}
       {% endwith %}

--- a/tests/base.py
+++ b/tests/base.py
@@ -98,10 +98,24 @@ class WebTestBase(WebTestCommonMixin, django_functest.FuncWebTestMixin, TestCase
     pass
 
 
-@unittest.skipIf(os.environ.get('INCLUDE_SELENIUM_TESTS', '0') == '0', "Skipping Selenium tests")
+INCLUDE_SELENIUM_TESTS = os.environ.get('INCLUDE_SELENIUM_TESTS', '0') == '1'
+
+
+@unittest.skipIf(not INCLUDE_SELENIUM_TESTS, "Skipping Selenium tests")
 class SeleniumBase(WebTestCommonMixin, django_functest.FuncSeleniumMixin, StaticLiveServerTestCase):
     driver_name = "Chrome"
     display = os.environ.get('SELENIUM_SHOW_BROWSER', '0') == '1'
+
+    if not INCLUDE_SELENIUM_TESTS:
+        # Don't call super() in setUpClass(), it will attempt to instatiate
+        # a browser instance which is slow and might fail
+        @classmethod
+        def setUpClass(cls):
+            pass
+
+        @classmethod
+        def tearDownClass(cls):
+            pass
 
 
 class ArticleWebTestUtils(object):

--- a/tests/base.py
+++ b/tests/base.py
@@ -101,6 +101,7 @@ class WebTestBase(WebTestCommonMixin, django_functest.FuncWebTestMixin, TestCase
 @unittest.skipIf(os.environ.get('INCLUDE_SELENIUM_TESTS', '0') == '0', "Skipping Selenium tests")
 class SeleniumBase(WebTestCommonMixin, django_functest.FuncSeleniumMixin, StaticLiveServerTestCase):
     driver_name = "Chrome"
+    display = os.environ.get('SELENIUM_SHOW_BROWSER', '0') == '1'
 
 
 class ArticleWebTestUtils(object):

--- a/tests/base.py
+++ b/tests/base.py
@@ -39,17 +39,23 @@ class TestBase(TestCase):
         )
 
 
-class ArticleTestBase(TestCase):
+class RequireRootArticleMixin(object):
+
+    def setUp(self):
+        super(RequireRootArticleMixin, self).setUp()
+        self.root = URLPath.create_root()
+        self.root_article = URLPath.root().article
+        rev = self.root_article.current_revision
+        rev.title = "Root Article"
+        rev.content = "root article content"
+        rev.save()
+
+
+class ArticleTestBase(RequireRootArticleMixin, TestCase):
     """
     Sets up basic data for testing with an article and some revisions
     """
-
-    def setUp(self):
-
-        super(ArticleTestBase, self).setUp()
-
-        self.root = URLPath.create_root()
-        self.child1 = URLPath.create_article(self.root, 'test-slug', title="Test 1")
+    pass
 
 
 class WebTestBase(TestBase):
@@ -64,22 +70,9 @@ class WebTestBase(TestBase):
         c.login(username=SUPERUSER1_USERNAME, password=SUPERUSER1_PASSWORD)
 
 
-class ArticleWebTestBase(WebTestBase):
+class ArticleWebTestBase(RequireRootArticleMixin, WebTestBase):
 
     """Base class for web client tests, that sets up initial root article."""
-
-    def setUp(self):
-
-        super(ArticleWebTestBase, self).setUp()
-
-        response = self.c.post(
-            reverse('wiki:root_create'),
-            {'content': 'root article content', 'title': 'Root Article'},
-            follow=True
-        )
-
-        self.assertEqual(response.status_code, 200)  # sanity check
-        self.root_article = URLPath.root().article
 
     def get_by_path(self, path):
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -101,8 +101,6 @@ class SeleniumBase(WebTestCommonMixin, django_functest.FuncSeleniumMixin, Static
 
 class ArticleWebTestUtils(object):
 
-    """Base class for web client tests, that sets up initial root article."""
-
     def get_by_path(self, path):
         """
         Get the article response for the path.

--- a/tests/base.py
+++ b/tests/base.py
@@ -70,7 +70,7 @@ class WebTestBase(TestBase):
         c.login(username=SUPERUSER1_USERNAME, password=SUPERUSER1_PASSWORD)
 
 
-class ArticleWebTestBase(RequireRootArticleMixin, WebTestBase):
+class ArticleWebTestUtils(object):
 
     """Base class for web client tests, that sets up initial root article."""
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,6 +4,7 @@ from django.core.urlresolvers import reverse
 from django.template import Context, Template
 from django.test import TestCase
 from django.test.client import Client
+
 from wiki.models import URLPath
 
 try:
@@ -17,14 +18,10 @@ SUPERUSER1_USERNAME = 'admin'
 SUPERUSER1_PASSWORD = 'secret'
 
 
-class TestBase(TestCase):
-    """
-    Sets up basic data
-    """
+class RequireSuperuserMixin(object):
 
     def setUp(self):
-
-        super(TestCase, self).setUp()
+        super(RequireSuperuserMixin, self).setUp()
 
         try:
             from django.contrib.auth import get_user_model
@@ -37,6 +34,17 @@ class TestBase(TestCase):
             'nobody@example.com',
             SUPERUSER1_PASSWORD
         )
+
+
+class RequireBasicData(RequireSuperuserMixin):
+    """
+    Mixin that creates common data required for all tests.
+    """
+    pass
+
+
+class TestBase(RequireBasicData, TestCase):
+    pass
 
 
 class RequireRootArticleMixin(object):
@@ -58,13 +66,12 @@ class ArticleTestBase(RequireRootArticleMixin, TestBase):
     pass
 
 
-class WebTestBase(TestBase):
+# This is needed only for tests that use the Django test client,
+# which are being phased out.
 
+class DjangoClientTestBase(TestBase):
     def setUp(self):
-        """Login as the superuser created because we shall access restricted
-        views"""
-
-        super(WebTestBase, self).setUp()
+        super(DjangoClientTestBase, self).setUp()
 
         self.c = c = Client()
         c.login(username=SUPERUSER1_USERNAME, password=SUPERUSER1_PASSWORD)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
+import os
+import unittest
+
 import django_functest
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.urlresolvers import reverse
@@ -95,6 +98,7 @@ class WebTestBase(WebTestCommonMixin, django_functest.FuncWebTestMixin, TestCase
     pass
 
 
+@unittest.skipIf(os.environ.get('INCLUDE_SELENIUM_TESTS', '0') == '0', "Skipping Selenium tests")
 class SeleniumBase(WebTestCommonMixin, django_functest.FuncSeleniumMixin, StaticLiveServerTestCase):
     driver_name = "Chrome"
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+import django_functest
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.urlresolvers import reverse
 from django.template import Context, Template
 from django.test import TestCase
@@ -75,6 +77,26 @@ class DjangoClientTestBase(TestBase):
 
         self.c = c = Client()
         c.login(username=SUPERUSER1_USERNAME, password=SUPERUSER1_PASSWORD)
+
+
+
+class WebTestCommonMixin(RequireBasicData, django_functest.ShortcutLoginMixin):
+    """
+    Common setup required for WebTest and Selenium tests
+    """
+    def setUp(self):
+        super(WebTestCommonMixin, self).setUp()
+
+        self.shortcut_login(username=SUPERUSER1_USERNAME,
+                            password=SUPERUSER1_PASSWORD)
+
+
+class WebTestBase(WebTestCommonMixin, django_functest.FuncWebTestMixin, TestCase):
+    pass
+
+
+class SeleniumBase(WebTestCommonMixin, django_functest.FuncSeleniumMixin, StaticLiveServerTestCase):
+    driver_name = "Chrome"
 
 
 class ArticleWebTestUtils(object):

--- a/tests/base.py
+++ b/tests/base.py
@@ -51,7 +51,7 @@ class RequireRootArticleMixin(object):
         rev.save()
 
 
-class ArticleTestBase(RequireRootArticleMixin, TestCase):
+class ArticleTestBase(RequireRootArticleMixin, TestBase):
     """
     Sets up basic data for testing with an article and some revisions
     """

--- a/tests/base.py
+++ b/tests/base.py
@@ -71,9 +71,6 @@ class ArticleTestBase(RequireRootArticleMixin, TestBase):
     pass
 
 
-# This is needed only for tests that use the Django test client,
-# which are being phased out.
-
 class DjangoClientTestBase(TestBase):
     def setUp(self):
         super(DjangoClientTestBase, self).setUp()

--- a/tests/core/test_managers.py
+++ b/tests/core/test_managers.py
@@ -9,10 +9,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 from wiki.models import Article, URLPath
 from wiki.plugins.attachments.models import Attachment
 
-from ..base import ArticleWebTestBase
+from ..base import ArticleTestBase
 
 
-class ArticleManagerTests(ArticleWebTestBase):
+class ArticleManagerTests(ArticleTestBase):
 
     def test_queryset_methods_directly_on_manager(self):
 
@@ -46,7 +46,7 @@ class ArticleManagerTests(ArticleWebTestBase):
         self.assertEqual(Article.objects.none().active().count(), 0)
 
 
-class AttachmentManagerTests(ArticleWebTestBase):
+class AttachmentManagerTests(ArticleTestBase):
 
     def test_queryset_methods_directly_on_manager(self):
 
@@ -81,7 +81,7 @@ class AttachmentManagerTests(ArticleWebTestBase):
         self.assertEqual(Attachment.objects.none().active().count(), 0)
 
 
-class URLPathManagerTests(ArticleWebTestBase):
+class URLPathManagerTests(ArticleTestBase):
 
     def test_related_manager_works_with_filters(self):
         root = URLPath.root()

--- a/tests/core/test_markdown.py
+++ b/tests/core/test_markdown.py
@@ -44,6 +44,7 @@ class ArticleMarkdownTests(ArticleTestBase):
 class ResponsiveTableExtensionTests(TestCase):
 
     def setUp(self):
+        super(ResponsiveTableExtensionTests, self).setUp()
         self.md = markdown.Markdown(extensions=[
             'extra',
             ResponsiveTableExtension()

--- a/tests/core/test_template_tags.py
+++ b/tests/core/test_template_tags.py
@@ -42,7 +42,7 @@ class ArticleForObjectTemplatetagTest(TemplateTestCase):
     """
 
     def setUp(self):
-
+        super(ArticleForObjectTemplatetagTest, self).setUp()
         from wiki.templatetags import wiki_tags
         wiki_tags._cache = {}
 
@@ -163,6 +163,7 @@ class WikiRenderTest(TemplateTestCase):
     def tearDown(self):
         from wiki.core.plugins import registry
         registry._cache = {}
+        super(WikiRenderTest, self).tearDown()
 
     keys = ['article',
             'content',

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -8,10 +8,10 @@ from wiki import models
 from wiki.forms import validate_slug_numbers
 from wiki.models import reverse
 
-from ..base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
+from ..base import RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase
 
 
-class RootArticleViewViewTests(WebTestBase):
+class RootArticleViewViewTests(DjangoClientTestBase):
 
     """Tests for creating/viewing the root article."""
 
@@ -39,7 +39,7 @@ class RootArticleViewViewTests(WebTestBase):
         self.assertContains(response, 'test heading h1</h1>')
 
 
-class ArticleViewViewTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class ArticleViewViewTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     """
     Tests for article views, assuming a root article already created.
@@ -121,7 +121,7 @@ class ArticleViewViewTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTest
         self.assertNotContains(self.get_by_path(''), 'Sub Article 1')
 
 
-class CreateViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class CreateViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def test_create_nested_article_in_article(self):
 
@@ -180,7 +180,7 @@ class CreateViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
 
 
-class DeleteViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class DeleteViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def test_articles_cache_is_cleared_after_deleting(self):
 
@@ -220,7 +220,7 @@ class DeleteViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
         self.assertContains(self.get_by_path('TestCache/'), 'Content 2')
 
 
-class EditViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class EditViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def test_preview_save(self):
         """Test edit preview, edit save and messages."""
@@ -310,7 +310,7 @@ class EditViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
         self.assertContains(response, 'Edit')
 
 
-class SearchViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class SearchViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def test_query_string(self):
 
@@ -327,7 +327,7 @@ class SearchViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
         self.assertFalse(response.context['articles'])
 
 
-class DeletedListViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class DeletedListViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def test_deleted_articles_list(self):
         c = self.c
@@ -356,7 +356,7 @@ class DeletedListViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestB
         self.assertContains(response, 'Delete Me')
 
 
-class UpdateProfileViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class UpdateProfileViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def test_update_profile(self):
         c = self.c
@@ -373,7 +373,7 @@ class UpdateProfileViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTes
         self.assertEqual(test_auth.email, 'test@test.com')
 
 
-class MergeViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class MergeViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def test_merge_preview(self):
         """Test merge preview"""

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -304,8 +304,19 @@ class EditViewTestsWebTest(EditViewTestsBase, WebTestBase):
 
 
 class EditViewTestsSelenium(EditViewTestsBase, SeleniumBase):
-    pass
 
+    # Javascript only tests:
+    def test_preview_and_save(self):
+        self.get_url('wiki:edit', path='')
+        self.fill({
+            '#id_content': 'Some changed stuff',
+            '#id_summary': 'why edited',
+            '#id_title': 'wiki test'
+        })
+        self.click('#id_preview')
+        self.submit('#id_preview_save_changes')
+        new_revision = URLPath.root().article.current_revision
+        self.assertIn("Some changed stuff", new_revision.content)
 
 
 class SearchViewTest(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -8,7 +8,7 @@ from wiki import models
 from wiki.forms import validate_slug_numbers
 from wiki.models import reverse
 
-from ..base import ArticleWebTestBase, WebTestBase
+from ..base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
 
 
 class RootArticleViewViewTests(WebTestBase):
@@ -39,7 +39,7 @@ class RootArticleViewViewTests(WebTestBase):
         self.assertContains(response, 'test heading h1</h1>')
 
 
-class ArticleViewViewTests(ArticleWebTestBase):
+class ArticleViewViewTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     """
     Tests for article views, assuming a root article already created.
@@ -121,7 +121,7 @@ class ArticleViewViewTests(ArticleWebTestBase):
         self.assertNotContains(self.get_by_path(''), 'Sub Article 1')
 
 
-class CreateViewTest(ArticleWebTestBase):
+class CreateViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def test_create_nested_article_in_article(self):
 
@@ -180,7 +180,7 @@ class CreateViewTest(ArticleWebTestBase):
 
 
 
-class DeleteViewTest(ArticleWebTestBase):
+class DeleteViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def test_articles_cache_is_cleared_after_deleting(self):
 
@@ -220,7 +220,7 @@ class DeleteViewTest(ArticleWebTestBase):
         self.assertContains(self.get_by_path('TestCache/'), 'Content 2')
 
 
-class EditViewTest(ArticleWebTestBase):
+class EditViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def test_preview_save(self):
         """Test edit preview, edit save and messages."""
@@ -310,7 +310,7 @@ class EditViewTest(ArticleWebTestBase):
         self.assertContains(response, 'Edit')
 
 
-class SearchViewTest(ArticleWebTestBase):
+class SearchViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def test_query_string(self):
 
@@ -327,7 +327,7 @@ class SearchViewTest(ArticleWebTestBase):
         self.assertFalse(response.context['articles'])
 
 
-class DeletedListViewTest(ArticleWebTestBase):
+class DeletedListViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def test_deleted_articles_list(self):
         c = self.c
@@ -356,7 +356,7 @@ class DeletedListViewTest(ArticleWebTestBase):
         self.assertContains(response, 'Delete Me')
 
 
-class UpdateProfileViewTest(ArticleWebTestBase):
+class UpdateProfileViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def test_update_profile(self):
         c = self.c
@@ -373,7 +373,7 @@ class UpdateProfileViewTest(ArticleWebTestBase):
         self.assertEqual(test_auth.email, 'test@test.com')
 
 
-class MergeViewTest(ArticleWebTestBase):
+class MergeViewTest(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def test_merge_preview(self):
         """Test merge preview"""

--- a/tests/plugins/attachments/test_commands.py
+++ b/tests/plugins/attachments/test_commands.py
@@ -15,7 +15,7 @@ class TestAttachmentManagementCommands(TestManagementCommands):
     """
 
     def setUp(self):
-        TestManagementCommands.setUp(self)
+        super(TestAttachmentManagementCommands, self).setUp()
 
         self.test_file = tempfile.NamedTemporaryFile('w', delete=False, suffix=".txt")
         self.test_file.write("test")
@@ -33,3 +33,4 @@ class TestAttachmentManagementCommands(TestManagementCommands):
 
     def tearDown(self):
         os.unlink(self.test_file.name)
+        super(TestAttachmentManagementCommands, self).tearDown()

--- a/tests/plugins/attachments/test_commands.py
+++ b/tests/plugins/attachments/test_commands.py
@@ -6,6 +6,7 @@ import tempfile
 from tests.core.test_commands import TestManagementCommands
 
 from wiki.plugins.attachments import models
+from wiki.models import URLPath
 
 
 class TestAttachmentManagementCommands(TestManagementCommands):
@@ -18,6 +19,8 @@ class TestAttachmentManagementCommands(TestManagementCommands):
 
         self.test_file = tempfile.NamedTemporaryFile('w', delete=False, suffix=".txt")
         self.test_file.write("test")
+
+        self.child1 = URLPath.create_article(self.root, 'test-slug', title="Test 1")
 
         self.attachment1 = models.Attachment.objects.create(
             article=self.child1.article

--- a/tests/plugins/attachments/test_views.py
+++ b/tests/plugins/attachments/test_views.py
@@ -5,10 +5,10 @@ from io import BytesIO
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.urlresolvers import reverse
 
-from ...base import ArticleWebTestBase
+from ...base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
 
 
-class AttachmentTests(ArticleWebTestBase):
+class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def setUp(self):
         super(AttachmentTests, self).setUp()

--- a/tests/plugins/attachments/test_views.py
+++ b/tests/plugins/attachments/test_views.py
@@ -5,10 +5,10 @@ from io import BytesIO
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.urlresolvers import reverse
 
-from ...base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
+from ...base import RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase
 
 
-class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def setUp(self):
         super(AttachmentTests, self).setUp()

--- a/tests/plugins/globalhistory/test_globalhistory.py
+++ b/tests/plugins/globalhistory/test_globalhistory.py
@@ -4,9 +4,9 @@ import sys
 
 from django.core.urlresolvers import reverse
 from wiki.models import URLPath
-from ...base import ArticleWebTestBase
+from ...base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
 
-class GlobalhistoryTests(ArticleWebTestBase):
+class GlobalhistoryTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def _assertRegex(self, a, b):
         if sys.version_info >= (3, 2):

--- a/tests/plugins/globalhistory/test_globalhistory.py
+++ b/tests/plugins/globalhistory/test_globalhistory.py
@@ -4,9 +4,9 @@ import sys
 
 from django.core.urlresolvers import reverse
 from wiki.models import URLPath
-from ...base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
+from ...base import RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase
 
-class GlobalhistoryTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class GlobalhistoryTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def _assertRegex(self, a, b):
         if sys.version_info >= (3, 2):

--- a/tests/plugins/globalhistory/test_globalhistory.py
+++ b/tests/plugins/globalhistory/test_globalhistory.py
@@ -14,9 +14,6 @@ class GlobalhistoryTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoCli
         else:
             return self.assertRegexpMatches(a, b)
 
-    def setUp(self):
-        super(GlobalhistoryTests, self).setUp()
-
     def test_history(self):
         url = reverse('wiki:globalhistory')
 

--- a/tests/plugins/images/test_views.py
+++ b/tests/plugins/images/test_views.py
@@ -11,10 +11,10 @@ from wiki.models import URLPath
 from wiki.plugins.images import models
 from wiki.plugins.images.wiki_plugin import ImagePlugin
 
-from ...base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
+from ...base import RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase
 
 
-class ImageTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
+class ImageTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
 
     def _assertRegex(self, a, b):
         if sys.version_info >= (3, 2):

--- a/tests/plugins/images/test_views.py
+++ b/tests/plugins/images/test_views.py
@@ -11,10 +11,10 @@ from wiki.models import URLPath
 from wiki.plugins.images import models
 from wiki.plugins.images.wiki_plugin import ImagePlugin
 
-from ...base import ArticleWebTestBase
+from ...base import RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase
 
 
-class ImageTests(ArticleWebTestBase):
+class ImageTests(RequireRootArticleMixin, ArticleWebTestUtils, WebTestBase):
 
     def _assertRegex(self, a, b):
         if sys.version_info >= (3, 2):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -43,6 +43,7 @@ MIDDLEWARE_CLASSES = [
 ]
 USE_TZ = True
 SECRET_KEY = 'b^fv_)t39h%9p40)fnkfblo##jkr!$0)lkp6bpy!fi*f$4*92!'
+STATIC_URL = '/static/'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/tests/testdata/urls.py
+++ b/tests/testdata/urls.py
@@ -24,6 +24,7 @@ if settings.DEBUG:
     ]
 
 urlpatterns += [
+    url(r'^django_functest/', include('django_functest.urls')),
     url(r'^notify/', get_notify_pattern()),
     url(r'', get_wiki_pattern())
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-# Ensure you add to .travis.yml if you add here
-envlist = {py27,py34,py35}-django{18,19,110}
+# Ensure you add to .travis.yml if you add here, using `tox -l`
+envlist = {py27,py34,py35}-django{18,19,110,111}
 
 [testenv]
 
@@ -27,6 +27,7 @@ deps =
      django18: Django==1.8.2
      django19: Django==1.9
      django110: Django==1.10.2
+     django111: Django==1.11
      django-mptt==0.8.6
      django-sekizai==0.10.0
      sorl-thumbnail==12.3

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/src
 
 commands =
-     {envbindir}/pytest --basetemp={envtmpdir} --ds=tests.settings --cov=src/wiki --cov-config .coveragerc
+     {toxinidir}/runtests.py --basetemp={envtmpdir} --ds=tests.settings --cov=src/wiki --cov-config .coveragerc
 
 usedevelop = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ usedevelop = true
 
 deps =
      coverage
-     pytest
-     pytest-django
-     pytest-cov
+     pytest==3.0.7
+     pytest-django==3.1.2
+     pytest-cov==2.4.0
      Pillow==2.3.0
      django-classy-tags==0.4
      six>=1.9

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,8 @@ deps =
      django-mptt==0.8.6
      django-sekizai==0.10.0
      sorl-thumbnail==12.3
+     django-functest==1.0.1
+     django-webtest==1.9.1
 
 basepython =
      py27: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,9 @@ deps =
      django18: Django==1.8.2
      django19: Django==1.9
      django110: Django==1.10.2
-     django{18,19,110}: django-mptt==0.8.6
-     django{18,19,110}: django-sekizai==0.10.0
-     django{18,19,110}: sorl-thumbnail==12.3
+     django-mptt==0.8.6
+     django-sekizai==0.10.0
+     sorl-thumbnail==12.3
 
 basepython =
      py27: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = {py27,py34,py35}-django{18,19,110,111}
 
 [testenv]
 
+passenv = INCLUDE_SELENIUM_TESTS SELENIUM_SHOW_BROWSER
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/src
 


### PR DESCRIPTION
This is a PR for Django 1.11 support, refs #614, using the approach described in
https://github.com/django-wiki/django-wiki/pull/624#issuecomment-298289218

I didn't start from #624 just because it was simpler to start from a clean sheet, and I had already done so.

Some additional notes, beyond what is the commit messages:

1. I did a fair bit of refactoring of test classes. This was basically because you have test base classes being used for two purposes - one is essentially fixture creation, the other is different types of test (Django client, WebTest, Selenium). To avoid combinatorial explosion of base classes, now most fixtures are provided by mixins which can be added to any test.

   I also had to fix a fair few fragile tests.

2. I had to rename the existing 'WebTestBase' to 'DjangoClientTestBase', otherwise there is just confusion due to two meanings of 'WebTest'.

3. The appearance of the edit page is now different - the 'action bar' containing delete, preview and save buttons no longer spans the whole width. This is due to how the HTML needs to nest, but it also makes more logical sense, since the forms in the side bar are actually separate and submit separately from the main one.

4. The edit page is now significantly different under the hood, though almost the same in terms of how it looks behaves. It turns out a lot of the Javascript was unnecessary, using things like 'formtarget' and 'formaction' - see http://caniuse.com/#feat=form-submit-attributes and https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button .  All the inline 'onclick' style Javascript is gone.

5. I added a utility for running tests. With the increase in options available, this makes the options much easier to find.

6. Selenium tests are off by default. But I ran them on all environments and everything passes.

7. I only added Chrome tests, and not Firefox. It's easy to add both if required, or have a switch, but Firefox is trickier, for reasons described here: http://django-functest.readthedocs.io/en/latest/installation.html#dependencies


8. There is a lot more that could be done with using django-functest. Most of the view tests could be rewritten to be clearer, shorter and less dependent on internals. We could also do proper testing of the 'concurrent editing' situation, using http://django-functest.readthedocs.io/en/latest/common.html#django_functest.FuncCommonApi.new_browser_session (for either WebTest or Selenium tests, or both).

   However, all these I left for a later day. I only rewrote the tests for creating the root article, and the tests for editing an article - and, of course, finally fixed the bug with Django 1.11!


