### PR TITLE
Global history: Show only last revision of every article

### DIFF
--- a/src/wiki/plugins/globalhistory/templates/wiki/plugins/globalhistory/globalhistory.html
+++ b/src/wiki/plugins/globalhistory/templates/wiki/plugins/globalhistory/globalhistory.html
@@ -8,11 +8,24 @@
 <h1>{% trans "Global history" %}</h1>
 
 {% spaceless %}
-<p class="lead">
-  {% with paginator.object_list.count as cnt %}
-      List of all <strong>{{ cnt }} changes</strong> in the wiki.
-  {% endwith %}
-</p>
+<div class="row">
+  <div class="lead col-xs-8">
+    {% with paginator.object_list.count as cnt %}
+       List of all <strong>{{ cnt }} changes</strong> in the wiki.
+    {% endwith %}
+  </div>
+  <div class="pull-right">
+    <a class="btn btn-default"
+       {% if only_last == "1" %}
+         href="{% url 'wiki:globalhistory' only_last=0 %}">
+         {% trans "Show all revisions of all articles" %}
+       {% else %}
+         href="{% url 'wiki:globalhistory' only_last=1 %}">
+         {% trans "Show last revision of every article" %}
+       {% endif %}
+    </a>
+  </div>
+</div>
 
 <div class="row">
   {% if revisions %}

--- a/src/wiki/plugins/globalhistory/templates/wiki/plugins/globalhistory/globalhistory.html
+++ b/src/wiki/plugins/globalhistory/templates/wiki/plugins/globalhistory/globalhistory.html
@@ -11,7 +11,7 @@
 <div class="row">
   <div class="lead col-xs-8">
     {% with paginator.object_list.count as cnt %}
-       List of all <strong>{{ cnt }} changes</strong> in the wiki.
+       {% blocktrans %}List of all <strong>{{ cnt }} changes</strong> in the wiki.{% endblocktrans %}
     {% endwith %}
   </div>
   <div class="pull-right">
@@ -45,11 +45,11 @@
         {% for article_revision in revisions %}
           <tr>
             <td>
-              {{article_revision.revision_number}}
+              {{ article_revision.revision_number }}
             </td>
             <td>
               <a href="{% url 'wiki:get' article_revision.article.pk %}">
-                {{article_revision.article}}
+                {{ article_revision.article }}
               </a>
             </td>
             <td>

--- a/src/wiki/plugins/globalhistory/views.py
+++ b/src/wiki/plugins/globalhistory/views.py
@@ -23,7 +23,7 @@ class GlobalHistory(ListView):
     def get_queryset(self):
         if self.only_last == '1':
             return self.model.objects.can_read(self.request.user) \
-                        .filter(article__current_revision = F('id')).order_by('-modified')
+                .filter(article__current_revision=F('id')).order_by('-modified')
         else:
             return self.model.objects.can_read(self.request.user).order_by('-modified')
 

--- a/src/wiki/plugins/globalhistory/views.py
+++ b/src/wiki/plugins/globalhistory/views.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.db.models import F
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 from django.views.generic import ListView
@@ -15,8 +16,17 @@ class GlobalHistory(ListView):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
+        self.only_last = kwargs.get('only_last', 0)
         return super(GlobalHistory, self).dispatch(
             request, *args, **kwargs)
 
     def get_queryset(self):
-        return self.model.objects.can_read(self.request.user).order_by('-modified')
+        if self.only_last == '1':
+            return self.model.objects.can_read(self.request.user) \
+                        .filter(article__current_revision = F('id')).order_by('-modified')
+        else:
+            return self.model.objects.can_read(self.request.user).order_by('-modified')
+
+    def get_context_data(self, **kwargs):
+        kwargs['only_last'] = self.only_last
+        return super(GlobalHistory, self).get_context_data(**kwargs)

--- a/src/wiki/plugins/globalhistory/wiki_plugin.py
+++ b/src/wiki/plugins/globalhistory/wiki_plugin.py
@@ -12,6 +12,7 @@ class GlobalHistoryPlugin(BasePlugin):
     slug = settings.SLUG
     urlpatterns = {'root': [
         url(r'^$', views.GlobalHistory.as_view(), name='globalhistory'),
+        url('^(?P<only_last>[01])/$', views.GlobalHistory.as_view(), name='globalhistory'),
     ]}
 
     def __init__(self):

--- a/tests/plugins/globalhistory/test_globalhistory.py
+++ b/tests/plugins/globalhistory/test_globalhistory.py
@@ -65,12 +65,12 @@ class GlobalhistoryTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoCli
         self._assertRegex(response.rendered_content, expected)
 
         response = self.c.post(reverse('wiki:edit', kwargs={'path': 'testhistory2/'}),
-            {'content': 'a page modified',
-             'current_revision': str(urlpath.article.current_revision.id),
-             'preview': '0',
-             'save': '1',
-             'summary': 'Testing Revision',
-             'title': 'TestHistory2Mod'})
+                               {'content': 'a page modified',
+                                'current_revision': str(urlpath.article.current_revision.id),
+                                'preview': '0',
+                                'save': '1',
+                                'summary': 'Testing Revision',
+                                'title': 'TestHistory2Mod'})
 
         expected = (
             '(?s)<title>Global history.*'


### PR DESCRIPTION
Added a new option to the global history plugin to

- show all revisions of all articles or to
- show only the last revision of every article.

Toggling between these two is as well possible on the global history
page via a button.
