### PR TITLE
Since Bootstrap 3 error messages must be shown with alert-danger

### DIFF
--- a/testproject/testproject/settings/base.py
+++ b/testproject/testproject/settings/base.py
@@ -13,6 +13,7 @@ from __future__ import unicode_literals
 
 import os
 
+from django.contrib.messages import constants as messages
 from django.core.urlresolvers import reverse_lazy
 
 
@@ -152,6 +153,9 @@ STATIC_ROOT = os.path.join(PROJECT_DIR, 'static')
 MEDIA_ROOT = os.path.join(PROJECT_DIR, 'media')
 MEDIA_URL = '/media/'
 
+MESSAGE_TAGS = {
+    messages.ERROR: 'danger'
+}
 
 WIKI_ANONYMOUS_WRITE = True
 WIKI_ANONYMOUS_CREATE = False


### PR DESCRIPTION
Since Bootstrap 3 alert-error is renamed to alert-danger. As a result
messages.error() does not use by default the correct class anymore.
This PR changes the settings for the test project, so that that one
uses the alert-danger class.
