### PR TITLE
Python 3.5 and 3.6 are now available from travis images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,16 @@
-# THANKS!
-# https://travis-ci.org/peterbe/premailer
-
-# This indicates to Travis that we will not use or need sudo
-# so that we can benefit from and use the cache->directories
-# directive.
-
-sudo: false
+# Because Python 3.6 is available on GCE
+sudo: required
 dist: trusty
 
 env: PIP_DOWNLOAD_CACHE="pip_cache"
 
 language: python
 
+python: 3.6
+
 addons:
   apt:
-    sources:
-      - deadsnakes
     packages:
-      - python3.5
-      - python3.5-dev
       - libjpeg8
       - libjpeg8-dev
 
@@ -36,10 +28,11 @@ env:
 - TOXENV=py35-django19
 - TOXENV=py35-django110
 - TOXENV=py35-django111
+- TOXENV=py36-django111
 - TOXENV=lint
 
 install:
-  - pip install tox>=2.1 coveralls
+  - pip install tox>=2.1
 
 script:
   - tox -e $TOXENV

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,6 +23,7 @@ django-wiki 0.3 (unreleased)
  * Crop paginator window when there are >9 pages in a list (Frank Loemker) #646
  * Render django.contrib.messages with template tag and inclusion template: Configurable and bootstrap 3 compatible (Benjamin Bach and Frank Loemker) #654
  * Don't hardcode redirect url in account update view (Benjamin Bach) #650
+ * Python 3.6 support added to test matrix (Benjamin Bach) #664
 
 
 django-wiki 0.2.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 # Ensure you add to .travis.yml if you add here, using `tox -l`
-envlist = {py27,py34,py35}-django{18,19,110,111},lint
+envlist = {py27,py34,py35,py36}-django{18,19,110,111},lint
 
 [testenv]
 
 passenv = INCLUDE_SELENIUM_TESTS SELENIUM_SHOW_BROWSER
 
 commands =
-     {toxinidir}/runtests.py --basetemp={envtmpdir} --ds=tests.settings --cov=src/wiki --cov-config .coveragerc
+     {toxinidir}/runtests.py --basetemp={envtmpdir} --ds=tests.settings --cov=src/wiki --cov-config .coveragerc {posargs}
 
 usedevelop = true
 
@@ -38,6 +38,7 @@ basepython =
      py27: python2.7
      py34: python3.4
      py35: python3.5
+     py36: python3.6
 
 
 [testenv:lint]


### PR DESCRIPTION
```
Trusty GCE images should now have Python 3.5 and 3.6 pre-installed.

sudo: required
dist: trusty
```

Also allows positional arguments to specify test, for instance:

    tox -e py35-django110 tests/core/test_basic.py


Ref: #644