### PR TITLE
Prevent processing multiple edit submits in a row.

### DIFF
--- a/src/wiki/templates/wiki/edit.html
+++ b/src/wiki/templates/wiki/edit.html
@@ -98,7 +98,13 @@
       $("#article_edit_form").data("changed",true);
     }
     window.onbeforeunload = confirmOnPageExit;
-    $("#article_edit_form").on("submit", function () {
+    var click_time = 0;
+    $("#article_edit_form").on("submit", function (ev) {
+        now = Date.now();
+        elapsed = now-click_time;
+        click_time = now;
+        if (elapsed < 3000)
+            ev.preventDefault();
         window.onbeforeunload = null;
         return true;
     });


### PR DESCRIPTION
When accidentally double clicking the "Save changes" button in the edit
form all requests are processed, resulting finally in an edit view with

    A new revision of the article was successfully added.

on top and the error

    While you were editing, someone else changed the revision. Your
    contents have been automatically merged with the new contents. Please
    review the text below.

next to it. Prevent this by allowing only one submit action in 3 seconds.
