### PR TITLE
Fix for "Restore attachments"

### DIFF
--- a/src/wiki/plugins/attachments/models.py
+++ b/src/wiki/plugins/attachments/models.py
@@ -197,7 +197,7 @@ def on_revision_delete(instance, *args, **kwargs):
 @disable_signal_for_loaddata
 def on_attachment_revision_pre_save(**kwargs):
     instance = kwargs['instance']
-    if kwargs.get('created', False):
+    if instance._state.adding:
         update_previous_revision = (
             not instance.previous_revision and
             instance.attachment and


### PR DESCRIPTION
Restoring attachments does not work anymore since
0d84a9cb0093f0669f5a589c0cbb238b19c7a8b1,
as previous_revision is not set anymore for the new
revision when deleting the attachment. But that is needed for
restoring the attachment.  Line from the index.html template:

    if attachment.current_revision.previous_revision.id

The reason seems to be that "created" is used in the pre_save attachment
hook to check if the instance was created or updated, but only the
post_save signal provides a created argument, not prev_save.

So for deciding if the instance is updated or created something else
needs to be used, e.g instance._state.adding.
