### PR TITLE
Fix tests by pinning test dependency WebTest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
      sorl-thumbnail==12.3
      django-functest==1.0.1
      django-webtest==1.9.1
+     WebTest==2.0.27
 
 basepython =
      py27: python2.7


### PR DESCRIPTION
@floemker this fixes the sudden test failures that we have been seeing lately

@spookylukey FYI, upping from WebTest 2.0.27 to 2.0.28 broke tests, so I had to exclude it. I'm not sure what causes the problem, but it's easy to reproduce (just remove the pinned version from tox.ini) - it seems that the login emulation doesn't work. Here's the changeset in WebTest: https://github.com/Pylons/webtest/compare/2.0.27...2.0.28