### PR TITLE
Extended attachment markdown macro.

### DIFF
--- a/src/wiki/plugins/attachments/markdown_extensions.py
+++ b/src/wiki/plugins/attachments/markdown_extensions.py
@@ -54,7 +54,8 @@ class AttachmentPreprocessor(markdown.preprocessors.Preprocessor):
                     kwargs={
                         'article_id': self.markdown.article.id,
                         'attachment_id': attachment.id,
-                    })
+                    }
+                )
 
                 # The readability of the attachment is decided relative
                 # to the owner of the original article.
@@ -79,14 +80,17 @@ class AttachmentPreprocessor(markdown.preprocessors.Preprocessor):
                         'title': title,
                         'size': size,
                         'attachment_can_read': attachment_can_read,
-                    })
+                    }
+                )
                 line = self.markdown.htmlStash.store(html, safe=True)
             except models.Attachment.DoesNotExist:
-                html = """<span class="attachment attachment-deleted">Attachment with ID #%s is deleted.</span>""" % attachment_id
+                html = (
+                    """<span class="attachment attachment-deleted">Attachment with ID """
+                    """#{} is deleted.</span>"""
+                ).format(attachment_id)
                 line = line.replace(
-                    '['+m.group(2)+']',
-                    self.markdown.htmlStash.store(
-                        html,
-                        safe=True))
+                    '[' + m.group(2) + ']',
+                    self.markdown.htmlStash.store(html, safe=True)
+                )
             new_text.append(before + line + after)
         return new_text

--- a/src/wiki/plugins/attachments/markdown_extensions.py
+++ b/src/wiki/plugins/attachments/markdown_extensions.py
@@ -10,7 +10,7 @@ from wiki.core.permissions import can_read
 from wiki.plugins.attachments import models
 
 ATTACHMENT_RE = re.compile(
-    r'(?P<before>.*)(\[attachment\:(?P<id>\d+)\])(?P<after>.*)',
+    r'(?P<before>.*)\[( *((attachment\:(?P<id>\d+))|(title\:\"(?P<title>[^\"]+)\")|(?P<size>size)))+\](?P<after>.*)',
     re.IGNORECASE)
 
 
@@ -34,49 +34,59 @@ class AttachmentPreprocessor(markdown.preprocessors.Preprocessor):
         new_text = []
         for line in lines:
             m = ATTACHMENT_RE.match(line)
-            if m:
-                attachment_id = m.group('id').strip()
-                before = self.run([m.group('before')])[0]
-                after = self.run([m.group('after')])[0]
-                try:
-                    attachment = models.Attachment.objects.get(
-                        articles__current_revision__deleted=False,
-                        id=attachment_id, current_revision__deleted=False,
-                        articles=self.markdown.article
-                    )
-                    url = reverse(
-                        'wiki:attachments_download',
-                        kwargs={
-                            'article_id': self.markdown.article.id,
-                            'attachment_id': attachment.id,
-                        })
+            if not m:
+                new_text.append(line)
+                continue
 
-                    # The readability of the attachment is decided relative
-                    # to the owner of the original article.
-                    # I.e. do not insert attachments in other articles that
-                    # the original uploader cannot read, that would be out
-                    # of scope!
-                    article_owner = attachment.article.owner
-                    if not article_owner:
-                        article_owner = AnonymousUser()
+            attachment_id = m.group('id').strip()
+            title = m.group('title')
+            size = m.group('size')
+            before = self.run([m.group('before')])[0]
+            after = self.run([m.group('after')])[0]
+            try:
+                attachment = models.Attachment.objects.get(
+                    articles__current_revision__deleted=False,
+                    id=attachment_id, current_revision__deleted=False,
+                    articles=self.markdown.article
+                )
+                url = reverse(
+                    'wiki:attachments_download',
+                    kwargs={
+                        'article_id': self.markdown.article.id,
+                        'attachment_id': attachment.id,
+                    })
 
-                    attachment_can_read = can_read(
-                        self.markdown.article, article_owner)
-                    html = render_to_string(
-                        "wiki/plugins/attachments/render.html",
-                        context={
-                            'url': url,
-                            'filename': attachment.original_filename,
-                            'attachment_can_read': attachment_can_read,
-                        })
-                    line = self.markdown.htmlStash.store(html, safe=True)
-                except models.Attachment.DoesNotExist:
-                    html = """<span class="attachment attachment-deleted">Attachment with ID #%s is deleted.</span>""" % attachment_id
-                    line = line.replace(
-                        m.group(2),
-                        self.markdown.htmlStash.store(
-                            html,
-                            safe=True))
-                line = before + line + after
-            new_text.append(line)
+                # The readability of the attachment is decided relative
+                # to the owner of the original article.
+                # I.e. do not insert attachments in other articles that
+                # the original uploader cannot read, that would be out
+                # of scope!
+                article_owner = attachment.article.owner
+                if not article_owner:
+                    article_owner = AnonymousUser()
+                if not title:
+                    title = attachment.original_filename
+                if size:
+                    size = attachment.current_revision.get_size()
+
+                attachment_can_read = can_read(
+                    self.markdown.article, article_owner)
+                html = render_to_string(
+                    "wiki/plugins/attachments/render.html",
+                    context={
+                        'url': url,
+                        'filename': attachment.original_filename,
+                        'title': title,
+                        'size': size,
+                        'attachment_can_read': attachment_can_read,
+                    })
+                line = self.markdown.htmlStash.store(html, safe=True)
+            except models.Attachment.DoesNotExist:
+                html = """<span class="attachment attachment-deleted">Attachment with ID #%s is deleted.</span>""" % attachment_id
+                line = line.replace(
+                    '['+m.group(2)+']',
+                    self.markdown.htmlStash.store(
+                        html,
+                        safe=True))
+            new_text.append(before + line + after)
         return new_text

--- a/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/index.html
+++ b/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/index.html
@@ -8,7 +8,11 @@
 <div class="row">
   <div class="col-lg-8">
     <p class="lead">{% trans "The following files are available for this article. Copy the markdown tag to directly refer to a file from the article text." %}</p>
-
+    <p> {% blocktrans %}
+      Complete markdown code syntax: <code>[attachment:id title:"text" size]</code><br>
+      &nbsp;&nbsp;title: Link text replacement for the file name.
+      size: Show file size after the title.
+    {% endblocktrans %} </p>
 
     {% for attachment in attachments %}
     <table class="table table-bordered table-striped">

--- a/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/render.html
+++ b/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/render.html
@@ -3,7 +3,9 @@
   Render an attachment to HTML in the markdown extension
 {% endcomment %}
 {% if not attachment_can_read %}
-<em>{% trans "This attachment is not permitted on this page." %}</em>
+  <em>{% trans "This attachment is not permitted on this page." %}</em>
 {% else %}
-<span class="attachment"><a href="{{ url }}" title="{% trans "Click to download" %} {{ filename }}">{{ filename }}</a>
+  <span class="attachment"><a href="{{ url }}" title="{% trans "Click to download" %} {{ filename }}">
+    {{ title }}{% if size %} [{{ size|filesizeformat }}]{% endif %}
+  </a>
 {% endif %}

--- a/tests/plugins/attachments/test_views.py
+++ b/tests/plugins/attachments/test_views.py
@@ -175,6 +175,6 @@ class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClient
         output = self.get_article('[attachment:1 title:"Test title 2" size]')
         expected = (
             '<span class="attachment"><a href=".*attachments/download/1/"'
-            ' title="Click to download test\.txt">\s*Test title 2 \[25\sbytes\]\s*</a>'
+            ' title="Click to download test\.txt">\s*Test title 2 \[25[^b]bytes\]\s*</a>'
         )
         self._assertRegex(output, expected)

--- a/tests/plugins/attachments/test_views.py
+++ b/tests/plugins/attachments/test_views.py
@@ -1,14 +1,22 @@
 from __future__ import print_function, unicode_literals
 
+import sys
 from io import BytesIO
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.urlresolvers import reverse
+from wiki.models import URLPath
 
 from ...base import RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase
 
 
 class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase):
+
+    def _assertRegex(self, a, b):
+        if sys.version_info >= (3, 2):
+            return self.assertRegex(a, b)
+        else:
+            return self.assertRegexpMatches(a, b)
 
     def setUp(self):
         super(AttachmentTests, self).setUp()
@@ -39,8 +47,8 @@ class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClient
         )
         return filestream
 
-    def _create_test_attachment(self):
-        url = reverse('wiki:attachments_index', kwargs={'path': ''})
+    def _create_test_attachment(self, path):
+        url = reverse('wiki:attachments_index', kwargs={'path': path})
         filestream = self._createTxtFilestream(self.test_data)
         response = self.c.post(url,
                                {'description': self.test_description,
@@ -55,7 +63,7 @@ class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClient
         Uploading a file should preserve the original filename.
         Uploading should not modify file in any way.
         """
-        self._create_test_attachment()
+        self._create_test_attachment('')
         # Check the object was created.
         attachment = self.article.shared_plugins_set.all()[0].attachment
         self.assertEqual(attachment.original_filename, 'test.txt')
@@ -125,7 +133,48 @@ class AttachmentTests(RequireRootArticleMixin, ArticleWebTestUtils, DjangoClient
         """
         Call the search view
         """
-        self._create_test_attachment()
+        self._create_test_attachment('')
         url = reverse('wiki:attachments_search', kwargs={'path': ''})
         response = self.c.get(url, {'query': self.test_description})
         self.assertContains(response, self.test_description)
+
+    def get_article(self, cont):
+        urlpath = URLPath.create_urlpath(
+            URLPath.root(),
+            "html_attach",
+            title="TestAttach",
+            content=cont
+        )
+        self._create_test_attachment(urlpath.path)
+        return urlpath.article.render()
+
+    def test_render(self):
+        output = self.get_article('[attachment:1]')
+        expected = (
+            '<span class="attachment"><a href=".*attachments/download/1/"'
+            ' title="Click to download test\.txt">\s*test\.txt\s*</a>'
+        )
+        self._assertRegex(output, expected)
+
+    def test_render_missing(self):
+        output = self.get_article('[attachment:2]')
+        expected = (
+            '<span class="attachment attachment-deleted">\s*Attachment with ID #2 is deleted.\s*</span>'
+        )
+        self._assertRegex(output, expected)
+
+    def test_render_title(self):
+        output = self.get_article('[attachment:1 title:"Test title"]')
+        expected = (
+            '<span class="attachment"><a href=".*attachments/download/1/"'
+            ' title="Click to download test\.txt">\s*Test title\s*</a>'
+        )
+        self._assertRegex(output, expected)
+
+    def test_render_title_size(self):
+        output = self.get_article('[attachment:1 title:"Test title 2" size]')
+        expected = (
+            '<span class="attachment"><a href=".*attachments/download/1/"'
+            ' title="Click to download test\.txt">\s*Test title 2 \[25\sbytes\]\s*</a>'
+        )
+        self._assertRegex(output, expected)


### PR DESCRIPTION
Extended markdown syntax for attachments:

    [attachment:id title:"text" size]

`title` and `size` are optional. If `title` is given it replaces the default link text, the
file name. If `size` is given the file size of the attachment is appended to the link text.

This is a superset of issue #214.
