### PR TITLE
Don't reference South in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,12 +74,11 @@ personal support.
 Currently, the model API is subject to smaller changes, and the plugin
 API seems pretty stable.
 
-South is used so no database changes will cause data loss. In order to
-customize the wiki, best idea is to override templates and create your
-own template tags. Do not make your own hard copy of this repository in
-order to fiddle with internal parts of the wiki -- this strategy will
-lead you to lose out on future updates with highly improved features
-and plugins. Possibly security updates as well!
+In order to customize the wiki, best idea is to override templates and create
+your own template tags. Do not make your own hard copy of this repository in
+order to fiddle with internal parts of the wiki -- this strategy will lead you
+to lose out on future updates with highly improved features and plugins.
+Possibly security updates as well!
 
 The release cycle has already begun, so you can administer django-wiki
 through Pypi and pip.


### PR DESCRIPTION
I was looking through django-wiki and was surprised to find South
mentioned in the README and so started looking elsewhere. On closer
investigation South has been removed and so should not be mentioned.

Signed-off-by: Jamie Lennox <jamielennox@gmail.com>