### PR TITLE
Extended documentation for the wiki settings.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -4,6 +4,33 @@ Settings
 The following settings are available for configuration through your project.
 All settings are customized by prefixing ``WIKI_``, so for instance
 ``URL_CASE_SENSITIVE`` should be configured as ``WIKI_URL_CASE_SENSITIVE``.
+For plugins the prefix is ``WIKI_PLUGINNAME_``, e.g. ``WIKI_IMAGES`` for the
+images plugin.
 
 .. automodule:: wiki.conf.settings
    :members:
+
+Plugin attachments
+-------------
+
+.. automodule:: wiki.plugins.attachments.settings
+   :members:
+
+Plugin images
+-------------
+
+.. automodule:: wiki.plugins.images.settings
+   :members:
+
+Plugin links
+-------------
+
+.. automodule:: wiki.plugins.links.settings
+   :members:
+
+Plugin macros
+-------------
+
+.. automodule:: wiki.plugins.macros.settings
+   :members:
+

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -106,7 +106,7 @@ MARKDOWN_HTML_ATTRIBUTES.update(
 )
 
 #: Allowed inline styles in Markdown article contents, default is no styles
-#: (empty list)
+#: (empty list).
 MARKDOWN_HTML_STYLES = (
     getattr(
         django_settings,
@@ -121,7 +121,7 @@ _project_defined_attrs = getattr(
     False)
 
 # If styles are allowed but no custom attributes are defined, we allow styles
-# for all kinds of tags
+# for all kinds of tags.
 if MARKDOWN_HTML_STYLES and not _project_defined_attrs:
     MARKDOWN_HTML_ATTRIBUTES['*'] = 'style'
 
@@ -147,7 +147,7 @@ LOG_IPS_ANONYMOUS = getattr(django_settings, 'WIKI_LOG_IPS_ANONYMOUS', True)
 #: Do we want to log IPs of logged in users?
 LOG_IPS_USERS = getattr(django_settings, 'WIKI_LOG_IPS_USERS', False)
 
-#: Map from message.tag to bootstrap class name
+#: Mapping from message.tag to bootstrap class names.
 MESSAGE_TAG_CSS_CLASS = getattr(
     django_settings,
     'WIKI_MESSAGE_TAG_CSS_CLASS',
@@ -168,34 +168,34 @@ MESSAGE_TAG_CSS_CLASS = getattr(
 # in separate settings...
 
 #: A function returning True/False if a user has permission to
-#: read contents of an article + plugins
-#: Relevance: viewing articles and plugins
+#: read contents of an article and plugins.
+#: Relevance: Viewing articles and plugins.
 CAN_READ = getattr(django_settings, 'WIKI_CAN_READ', None)
 
 #: A function returning True/False if a user has permission to
-#: change contents, ie add new revisions to an article
-#: Often, plugins also use this
-#: Relevance: editing articles, changing revisions, editing plugins
+#: change contents, i.e. add new revisions to an article.
+#: Often, plugins also use this.
+#: Relevance: Editing articles, changing revisions, editing plugins.
 CAN_WRITE = getattr(django_settings, 'WIKI_CAN_WRITE', None)
 
 #: A function returning True/False if a user has permission to assign
-#: permissions on an article
-#: Relevance: changing owner and group membership
+#: permissions on an article.
+#: Relevance: Changing owner and group membership.
 CAN_ASSIGN = getattr(django_settings, 'WIKI_CAN_ASSIGN', None)
 
-#: A function returning True/False if the owner of an article has permission to change
-#: the group to a user's own groups
-#: Relevance: changing group membership
+#: A function returning True/False if the owner of an article has permission
+#: to change the group to a user's own groups.
+#: Relevance: Changing group membership.
 CAN_ASSIGN_OWNER = getattr(django_settings, 'WIKI_ASSIGN_OWNER', None)
 
 #: A function returning True/False if a user has permission to change
-#: read/write access for groups and others
+#: read/write access for groups and others.
 CAN_CHANGE_PERMISSIONS = getattr(
     django_settings,
     'WIKI_CAN_CHANGE_PERMISSIONS',
     None)
 
-#: Specifies if a user has access to soft deletion of articles
+#: Specifies if a user has access to soft deletion of articles.
 CAN_DELETE = getattr(django_settings, 'WIKI_CAN_DELETE', None)
 
 #: A function returning True/False if a user has permission to change
@@ -206,25 +206,26 @@ CAN_MODERATE = getattr(django_settings, 'WIKI_CAN_MODERATE', None)
 #: new groups and users for the wiki.
 CAN_ADMIN = getattr(django_settings, 'WIKI_CAN_ADMIN', None)
 
-#: Treat anonymous (non logged in) users as the "other" user group
+#: Treat anonymous (i.e. non logged in) users as the "other" user group.
 ANONYMOUS = getattr(django_settings, 'WIKI_ANONYMOUS', True)
 
-#: Globally enable write access for anonymous users, if true anonymous users will be treated
-#: as the others_write boolean field on models.Article.
+#: Globally enable write access for anonymous users, if true anonymous users
+#: will be treated as the others_write boolean field on models.Article.
 ANONYMOUS_WRITE = getattr(django_settings, 'WIKI_ANONYMOUS_WRITE', False)
 
-#: Globally enable create access for anonymous users
-#: Defaults to ANONYMOUS_WRITE.
+#: Globally enable create access for anonymous users.
+#: Defaults to ``ANONYMOUS_WRITE``.
 ANONYMOUS_CREATE = getattr(
     django_settings,
     'WIKI_ANONYMOUS_CREATE',
     ANONYMOUS_WRITE)
 
-#: Default setting to allow anonymous users upload access (used in
-#: plugins.attachments and plugins.images).
+#: Default setting to allow anonymous users upload access. Used in
+#: plugins.attachments and plugins.images, and can be overwritten in
+#: these plugins.
 ANONYMOUS_UPLOAD = getattr(django_settings, 'WIKI_ANONYMOUS_UPLOAD', False)
 
-#: Sign up, login and logout views should be accessible
+#: Sign up, login and logout views should be accessible.
 ACCOUNT_HANDLING = getattr(django_settings, 'WIKI_ACCOUNT_HANDLING', True)
 
 #: Signup allowed? If it's not allowed, logged in superusers can still access
@@ -246,7 +247,7 @@ else:
 # OTHER SETTINGS #
 ##################
 
-#: Maximum amount of children to display in a menu before going "+more"
+#: Maximum amount of children to display in a menu before showing "+more".
 #: NEVER set this to 0 as it will wrongly inform the user that there are no
 #: children and for instance that an article can be safely deleted.
 SHOW_MAX_CHILDREN = getattr(django_settings, 'WIKI_SHOW_MAX_CHILDREN', 20)
@@ -257,8 +258,7 @@ USE_BOOTSTRAP_SELECT_WIDGET = getattr(
     'WIKI_USE_BOOTSTRAP_SELECT_WIDGET',
     True)
 
-#: dottedname of class used to construct urlpatterns for wiki.
-#:
+#: Dotted name of the class used to construct urlpatterns for the wiki.
 #: Default is wiki.urls.WikiURLPatterns. To customize urls or view handlers,
 #: you can derive from this.
 URL_CONFIG_CLASS = getattr(
@@ -266,7 +266,7 @@ URL_CONFIG_CLASS = getattr(
     'WIKI_URL_CONFIG_CLASS',
     'wiki.urls.WikiURLPatterns')
 
-#: Search view - dotted path denoting where the search view Class is located
+#: Search view - dotted path denoting where the search view Class is located.
 SEARCH_VIEW = getattr(
     django_settings,
     'WIKI_SEARCH_VIEW',
@@ -276,41 +276,41 @@ SEARCH_VIEW = getattr(
     'wiki.plugins.haystack.views.HaystackSearchView'
 )
 
-#: Seconds of timeout before renewing article cache. Articles are automatically
+#: Seconds of timeout before renewing the article cache. Articles are automatically
 #: renewed whenever an edit occurs but article content may be generated from
 #: other objects that are changed.
 CACHE_TIMEOUT = getattr(django_settings, 'WIKI_CACHE_TIMEOUT', 600)
 
-#: Choose the Group model to use. Defaults to django's auth.Group
+#: Choose the Group model to use for permission handling. Defaults to django's auth.Group.
 GROUP_MODEL = getattr(django_settings, 'WIKI_GROUP_MODEL', 'auth.Group')
 
 ###################
 # SPAM PROTECTION #
 ###################
 
-#: Maximum allowed revisions per hour for any given user or IP
+#: Maximum allowed revisions per hour for any given user or IP.
 REVISIONS_PER_HOUR = getattr(django_settings, 'WIKI_REVISIONS_PER_HOUR', 60)
 
-#: Maximum allowed revisions per minute for any given user or IP
+#: Maximum allowed revisions per minute for any given user or IP.
 REVISIONS_PER_MINUTES = getattr(
     django_settings,
     'WIKI_REVISIONS_PER_MINUTES',
     5)
 
-#: Maximum allowed revisions per hour for any given user or IP
+#: Maximum allowed revisions per hour for any anonymous user and any IP.
 REVISIONS_PER_HOUR_ANONYMOUS = getattr(
     django_settings,
     'WIKI_REVISIONS_PER_HOUR_ANONYMOUS',
     10)
 
-#: Maximum allowed revisions per hour for any given user or IP
+#: Maximum allowed revisions per minute for any anonymous user and any IP.
 REVISIONS_PER_MINUTES_ANONYMOUS = getattr(
     django_settings,
     'WIKI_REVISIONS_PER_MINUTES_ANONYMOUS',
     2)
 
-#: Number of minutes for looking up REVISIONS_PER_MINUTES and
-#: REVISIONS_PER_MINUTES_ANONYMOUS
+#: Number of minutes to look back for looking up ``REVISIONS_PER_MINUTES``
+#: and ``REVISIONS_PER_MINUTES_ANONYMOUS``.
 REVISIONS_MINUTES_LOOKBACK = getattr(
     django_settings,
     'WIKI_REVISIONS_MINUTES_LOOKBACK',
@@ -320,11 +320,12 @@ REVISIONS_MINUTES_LOOKBACK = getattr(
 # STORAGE #
 ###########
 
-#: Django Storage backend to use for images, attachments etc.
+#: Default Django storage backend to use for images, attachments etc.
 STORAGE_BACKEND = getattr(
     django_settings,
     'WIKI_STORAGE_BACKEND',
     default_storage)
 
-#: Use Sendfile
+#: Use Django Sendfile for sending out files? Otherwise the whole file is
+#: first read into memory and than send with a mime type based on the file.
 USE_SENDFILE = getattr(django_settings, 'WIKI_ATTACHMENTS_USE_SENDFILE', False)

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -326,6 +326,6 @@ STORAGE_BACKEND = getattr(
     'WIKI_STORAGE_BACKEND',
     default_storage)
 
-#: Use Django Sendfile for sending out files? Otherwise the whole file is
+#: Use django-sendfile for sending out files? Otherwise the whole file is
 #: first read into memory and than send with a mime type based on the file.
 USE_SENDFILE = getattr(django_settings, 'WIKI_ATTACHMENTS_USE_SENDFILE', False)

--- a/src/wiki/plugins/attachments/settings.py
+++ b/src/wiki/plugins/attachments/settings.py
@@ -35,7 +35,7 @@ UPLOAD_PATH = getattr(
 
 #: Should the upload path be obscurified? If so, a random hash will be
 #: added to the path such that someone can not guess the location of files
-#:(if you have restricted permissions and the files are still located
+#: (if you have restricted permissions and the files are still located
 #: within the web server's file system).
 UPLOAD_PATH_OBSCURIFY = getattr(
     django_settings,

--- a/src/wiki/plugins/attachments/settings.py
+++ b/src/wiki/plugins/attachments/settings.py
@@ -12,65 +12,65 @@ SLUG = "attachments"
 # Please see this note about support for UTF-8 files on django/apache:
 # https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/modwsgi/#if-you-get-a-unicodeencodeerror
 
-# Allow anonymous users upload access (not nice on an open network)
-# WIKI_ATTACHMENTS_ANONYMOUS can override this, otherwise the default
-# in wiki.conf.settings is used.
+#: Allow anonymous users upload access (not nice on an open network)
+#: ``WIKI_ATTACHMENTS_ANONYMOUS`` can override this, otherwise the default
+#: in ``wiki.conf.settings`` is used.
 ANONYMOUS = getattr(
     django_settings,
     'WIKI_ATTACHMENTS_ANONYMOUS',
     wiki_settings.ANONYMOUS_UPLOAD)
 
-# Maximum file sizes: Please using something like LimitRequestBody on
+# Maximum file sizes: Please use something like LimitRequestBody on
 # your web server.
 # http://httpd.apache.org/docs/2.2/mod/core.html#LimitRequestBody
 
-# Where to store article attachments, relative to MEDIA_ROOT
-# You should NEVER enable directory indexing in MEDIA_ROOT/UPLOAD_PATH !
-# Actually, you can completely disable serving it, if you want. Files are
-# sent to the user through a Django view that reads and streams a file.
+#: Where to store article attachments, relative to ``MEDIA_ROOT``.
+#: You should NEVER enable directory indexing in ``MEDIA_ROOT/UPLOAD_PATH``!
+#: Actually, you can completely disable serving it, if you want. Files are
+#: sent to the user through a Django view that reads and streams a file.
 UPLOAD_PATH = getattr(
     django_settings,
     'WIKI_ATTACHMENTS_PATH',
     'wiki/attachments/%aid/')
 
-# Should the upload path be obscurified? If so, a random hash will be added to the path
-# such that someone can not guess the location of files (if you have
-# restricted permissions and the files are still located within the web
-# server's
+#: Should the upload path be obscurified? If so, a random hash will be
+#: added to the path such that someone can not guess the location of files
+#:(if you have restricted permissions and the files are still located
+#: within the web server's file system).
 UPLOAD_PATH_OBSCURIFY = getattr(
     django_settings,
     'WIKI_ATTACHMENTS_PATH_OBSCURIFY',
     True)
 
-# Allowed extensions. Empty to disallow uploads completely.
-# No files are saved without appending ".upload" to the file to ensure that
-# your web server never actually executes some script.
-# Case insensitive.
-# You are asked to explicitly enter all file extensions that you want
-# to allow. For your own safety.
+#: Allowed extensions for attachments, empty to disallow uploads completely.
+#: If ``WIKI_ATTACHMENTS_APPEND_EXTENSION`` files are saved with an appended
+#: ".upload" to the file to ensure that your web server never actually executes
+#: some script. The extensions are case insensitive.
+#: You are asked to explicitly enter all file extensions that you want
+#: to allow. For your own safety.
 FILE_EXTENSIONS = getattr(
     django_settings, 'WIKI_ATTACHMENTS_EXTENSIONS',
     ['pdf', 'doc', 'odt', 'docx', 'txt'])
 
-# Storage backend to use, default is to use the same as the rest of the
-# wiki, which is set in WIKI_STORAGE_BACKEND, but you can override it
-# with WIKI_ATTACHMENTS_STORAGE_BACKEND
+#: Storage backend to use, default is to use the same as the rest of the
+#: wiki, which is set in ``WIKI_STORAGE_BACKEND``, but you can override it
+#: with ``WIKI_ATTACHMENTS_STORAGE_BACKEND``.
 STORAGE_BACKEND = getattr(
     django_settings,
     'WIKI_ATTACHMENTS_STORAGE_BACKEND',
     wiki_settings.STORAGE_BACKEND)
 
-# SAFETY FIRST! Only store files with an appended .upload extension to be sure
-# that something nasty does not get executed on the server.
+#: Store files always with an appended .upload extension to be sure that
+#: something nasty does not get executed on the server. SAFETY FIRST!
 APPEND_EXTENSION = getattr(
     django_settings,
     'WIKI_ATTACHMENTS_APPEND_EXTENSION',
     True)
 
-# Important for S3 backends etc.: If your storage backend does not have a .path
-# attribute for the file, but only a .url attribute, you should use False.
-# This will reveal the direct download URL so it does not work perfectly for
-# files you wish to be kept private.
+#: Important for e.g. S3 backends: If your storage backend does not have a .path
+#: attribute for the file, but only a .url attribute, you should use False.
+#: This will reveal the direct download URL so it does not work perfectly for
+#: files you wish to be kept private.
 USE_LOCAL_PATH = getattr(django_settings, 'WIKI_ATTACHMENTS_LOCAL_PATH', True)
 
 if (not USE_LOCAL_PATH) and APPEND_EXTENSION:

--- a/src/wiki/plugins/images/settings.py
+++ b/src/wiki/plugins/images/settings.py
@@ -8,10 +8,12 @@ SLUG = 'images'
 # Deprecated
 APP_LABEL = None
 
-# Where to store images
+#: Location where uploaded images are stored. ``%aid`` is replaced by the article id.
 IMAGE_PATH = getattr(django_settings, 'WIKI_IMAGES_PATH', "wiki/images/%aid/")
 
-# Sizes for image thumbnails
+#: Size for the image thumbnail included in the HTML text. If no specific
+#: size is given in the markdown tag the ``default`` size is used. If a
+#: specific size is given in the markdown tag that size is used.
 THUMBNAIL_SIZES = getattr(django_settings, 'WIKI_IMAGES_THUMBNAIL_SIZES', {
     'default': '250x250',
     'small': '150x150',
@@ -20,26 +22,26 @@ THUMBNAIL_SIZES = getattr(django_settings, 'WIKI_IMAGES_THUMBNAIL_SIZES', {
     'orig': None
 })
 
-# Storage backend to use, default is to use the same as the rest of the
-# wiki, which is set in WIKI_STORAGE_BACKEND, but you can override it
-# with WIKI_IMAGES_STORAGE_BACKEND
+#: Storage backend to use, default is to use the same as the rest of the
+#: wiki, which is set in ``WIKI_STORAGE_BACKEND``, but you can override it
+#: with ``WIKI_IMAGES_STORAGE_BACKEND``.
 STORAGE_BACKEND = getattr(
     django_settings,
     'WIKI_IMAGES_STORAGE_BACKEND',
     wiki_settings.STORAGE_BACKEND)
 
-# Should the upload path be obscurified? If so, a random hash will be added to the path
-# such that someone can not guess the location of files (if you have
-# restricted permissions and the files are still located within the web
-# server's
+#: Should the upload path be obscurified? If so, a random hash will be added
+#: to the path such that someone can not guess the location of files (if you
+#: have restricted permissions and the files are still located within the
+#: web server's file system).
 IMAGE_PATH_OBSCURIFY = getattr(
     django_settings,
     'WIKI_IMAGES_PATH_OBSCURIFY',
     True)
 
-# Allow anonymous users upload access (not nice on an open network)
-# WIKI_IMAGES_ANONYMOUS can override this, otherwise the default
-# in wiki.conf.settings is used.
+#: Allow anonymous users upload access (not nice on an open network).
+#: ``WIKI_IMAGES_ANONYMOUS`` can override this, otherwise the default
+#: in ``wiki.conf.settings`` is used.
 ANONYMOUS = getattr(
     django_settings,
     'WIKI_IMAGES_ANONYMOUS',

--- a/src/wiki/plugins/links/settings.py
+++ b/src/wiki/plugins/links/settings.py
@@ -2,4 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings as django_settings
 
+#: If a relative slug is used in a wiki markdown link and no article is
+#: found with the given slug starting at the current articles level a
+#: link to a not yet existing article is created. Creating the article
+#: can be done by following the link. This link will be relative to
+#: ``LOOKUP_LEVEL``. This should be the level that most articles are
+#: created at.
 LOOKUP_LEVEL = getattr(django_settings, 'WIKI_LINKS_LOOKUP_LEVEL', 2)

--- a/src/wiki/plugins/macros/settings.py
+++ b/src/wiki/plugins/macros/settings.py
@@ -5,6 +5,9 @@ from django.conf import settings as django_settings
 SLUG = 'macros'
 APP_LABEL = 'wiki'
 
+#: List of markdown extensions this plugin should support.
+#: ``article_list`` inserts a list of articles from the current level.
+#: ``toc`` inserts a table of contents matching the headings.
 METHODS = getattr(
     django_settings,
     'WIKI_PLUGINS_METHODS',


### PR DESCRIPTION
Use Sphinx compatible syntax for all wiki settings, including settings
from plugins, extended and corrected documentation for different wiki
settings, and extended the main settings page to include sections for
the different plugin settings.

This fixes issue #642.