### PR TITLE
Fix settings with Django 1.11

### DIFF
--- a/src/wiki/plugins/notifications/forms.py
+++ b/src/wiki/plugins/notifications/forms.py
@@ -110,7 +110,7 @@ class SubscriptionForm(PluginSettingsFormMixin, forms.Form):
     settings_write_access = False
 
     settings = SettingsModelChoiceField(
-        Settings,
+        None,
         empty_label=None,
         label=_('Settings')
     )


### PR DESCRIPTION
The notifications plugin uses a ModelChoiceField in it's settings. A
ModelChoiceField needs as first argument a QuerySet or initially None,
not a Model. Since Django 1.11 the provided queryset is already used in
the \_\_init\_\_() function, resulting in an AttributeError when the wrong
type is used here.

This fixed issue #676.
