### PR TITLE
Don't access a deleted URLPath.

### DIFF
--- a/src/wiki/models/urlpath.py
+++ b/src/wiki/models/urlpath.py
@@ -114,7 +114,10 @@ class URLPath(MPTTModel):
         If the cached ancestors were not set explicitly, they will be retrieved from
         the database.
         """
-        if not self.get_ancestors().exists():
+        # "not self.pk": HACK needed till PR#591 is included in all supported django-mptt
+        #   versions. Prevent accessing a deleted URLPath when deleting it from the admin
+        #   interface.
+        if not self.pk or not self.get_ancestors().exists():
             self._cached_ancestors = []
         if not hasattr(self, "_cached_ancestors"):
             self._cached_ancestors = list(


### PR DESCRIPTION
django-mptt calls \_\_str\_\_() for an already deleted tree. Prevent in this
case a "Cannot call get_ancestors on unsaved URLPath instances" exception.
This is a work around for an MPTT bug which is needed till PR
django-mptt/django-mptt#591 from MPTT is included in all supported MPTT
versions.

This fixes the exception from issue  #668, but is of course only a work around
for the real bug in MPTT.