### PR TITLE
show logout button if ACCOUNT_HANDLING is not set

### DIFF
--- a/src/wiki/templates/wiki/base_site.html
+++ b/src/wiki/templates/wiki/base_site.html
@@ -66,13 +66,13 @@
                       {% trans "Account Settings" %}
                     </a>
                   </li>
+                  {% endif %}
                   <li>
-                    <a href="{% url 'wiki:logout' %}">
+                    <a href="{{ "LOGOUT_URL"|wiki_settings }}">
                       <i class="fa fa-power-off"></i>
                       {% trans "Log out" %}
                     </a>
                   </li>
-                  {% endif %}
                   {% if user.is_superuser %}
                   <li>
                     <a href="{% url 'wiki:deleted_list' %}">


### PR DESCRIPTION
if ACCOUNT_HANDLING is not set, the logout button is missing in the user menu now. This change fix it