### PR TITLE
Fixed secondary search bar not submitting

### DIFF
--- a/src/wiki/templates/wiki/search.html
+++ b/src/wiki/templates/wiki/search.html
@@ -14,7 +14,7 @@
     <div class="input-group">
       <input type="search" class="form-control search-query" name="q" value="{{ search_query }}" />
       <span class="input-group-btn">
-        <button class="btn btn-default" type="button">
+        <button class="btn btn-default" type="search">
           <span class="fa fa-search"></span>
         </button>
       </span>


### PR DESCRIPTION
The Bug:

To reproduce: Use the search bar, try to search again in the 'secondary' search bar that appears directly above the results. The button doesn't work.

The secondary search bar button was not submitting in Chrome. Changing the type to 'search' fixes it.