### PR TITLE
allow plugins to modify Bleach tag lists

### DIFF
--- a/src/wiki/core/markdown/__init__.py
+++ b/src/wiki/core/markdown/__init__.py
@@ -36,10 +36,16 @@ class ArticleMarkdown(markdown.Markdown):
     def convert(self, text, *args, **kwargs):
         html = super(ArticleMarkdown, self).convert(text, *args, **kwargs)
         if settings.MARKDOWN_SANITIZE_HTML:
+            tags = settings.MARKDOWN_HTML_WHITELIST + plugin_registry.get_html_whitelist()
+
+            attrs = dict()
+            attrs.update(settings.MARKDOWN_HTML_ATTRIBUTES)
+            attrs.update(plugin_registry.get_html_attributes().items())
+
             html = bleach.clean(
                 html,
-                tags=settings.MARKDOWN_HTML_WHITELIST,
-                attributes=settings.MARKDOWN_HTML_ATTRIBUTES,
+                tags=tags,
+                attributes=attrs,
                 styles=settings.MARKDOWN_HTML_STYLES,
             )
         return html

--- a/src/wiki/core/plugins/registry.py
+++ b/src/wiki/core/plugins/registry.py
@@ -56,7 +56,6 @@ def register(PluginClass):
             'html_whitelist',
             []))
 
-    # TODO: should we sanitize the list somehow or do we trust plugins to 100%?
     _html_attributes.update(
         getattr(
             PluginClass,

--- a/src/wiki/core/plugins/registry.py
+++ b/src/wiki/core/plugins/registry.py
@@ -15,6 +15,8 @@ _settings_forms = []
 _markdown_extensions = []
 _article_tabs = []
 _sidebar = []
+_html_whitelist = []
+_html_attributes = {}
 
 
 def register(PluginClass):
@@ -48,6 +50,19 @@ def register(PluginClass):
             'markdown_extensions',
             []))
 
+    _html_whitelist.extend(
+        getattr(
+            PluginClass,
+            'html_whitelist',
+            []))
+
+    # TODO: should we sanitize the list somehow or do we trust plugins to 100%?
+    _html_attributes.update(
+        getattr(
+            PluginClass,
+            'html_attributes',
+            dict()))
+
 
 def get_plugins():
     """Get loaded plugins - do not call before all plugins are loaded."""
@@ -71,3 +86,12 @@ def get_sidebar():
 
 def get_settings_forms():
     return _settings_forms
+
+
+def get_html_whitelist():
+    """Returns additional html tags that should be whitelisted"""
+    return _html_whitelist
+
+def get_html_attributes():
+    """Returns additional html attributes that should be whitelisted"""
+    return _html_attributes


### PR DESCRIPTION
some plugins already needs modify the bleach tags whitelist (plugins/images). This changeset add two options to a plugin class:

- `html_whitelist` - list of http tags to be added to bleach whitelist
- `html_attributes` - dictionary of http attributes to be added to bleach whitelist in the format
   _http tag : [ allowed attributes ]_