### PR TITLE
Add context to the 'Summary' string

### DIFF
--- a/src/wiki/forms.py
+++ b/src/wiki/forms.py
@@ -16,6 +16,7 @@ from django.forms.widgets import HiddenInput
 from django.utils import timezone
 from django.utils.html import conditional_escape, escape
 from django.utils.safestring import mark_safe
+from django.utils.translation import pgettext_lazy
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 from django.shortcuts import get_object_or_404
@@ -218,7 +219,7 @@ class EditForm(forms.Form, SpamProtectionMixin):
         widget=getEditor().get_widget())  # @UndefinedVariable
 
     summary = forms.CharField(
-        label=_('Summary'),
+        label=pgettext_lazy('Revision comment', 'Summary'),
         help_text=_(
             'Give a short reason for your edit, which will be stated in the revision log.'),
         required=False)
@@ -407,7 +408,7 @@ class CreateForm(forms.Form, SpamProtectionMixin):
         widget=getEditor().get_widget())  # @UndefinedVariable
 
     summary = forms.CharField(
-        label=_('Summary'),
+        label=pgettext_lazy('Revision comment', 'Summary'),
         help_text=_("Write a brief message for the article's history log."),
         required=False)
 


### PR DESCRIPTION
Currently the 'Summary' string in django-wiki collides with the same string in django-admin. It results in django-admin's version being used if `django.contrib.admin` was listed earlier in `INSTALLED_APPS`.

At least Russian translation of django-admin's 'Summary' string is quite bad. It may be the case for other languages too.

I didn't find a clean way to make a fallback to the previous translations. It means that 'Summary' won't be translated until new translation are added in transifex and exported to the django-wiki repository. Please tell me if you know how to do it.