### PR TITLE
Remove delete_subtree bare except

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,15 @@ The next release series **0.3** will support Django 1.11. Likewise, it will be
 the last series with Python 2 support.
 
 
+django-wiki 0.3dev (unreleased master)
+--------------------------------------
+
+**Changed**
+
+ * Removed exception catch all in ``URLPath.delete_subtree`` which silenced errors while delete articles with descendents
+
+
+
 django-wiki 0.3b3
 -----------------
 

--- a/src/wiki/models/urlpath.py
+++ b/src/wiki/models/urlpath.py
@@ -155,12 +155,7 @@ class URLPath(MPTTModel):
         NB! This deletes this urlpath, its children, and ALL of the related
         articles. This is a purged delete and CANNOT be undone.
         """
-        try:
-            self._delete_subtree()
-        except:
-            # Not sure why any exception is getting caught here? Have we had
-            # unresolved database integrity errors?
-            log.exception("Exception deleting article subtree.")
+        self._delete_subtree()
 
     @classmethod
     def root(cls):


### PR DESCRIPTION
Causes linting errors, moreover would potentially cause an operation to unintentionally fail silently.