### PR TITLE
Sort search results, images, and attachments.

### DIFF
--- a/src/wiki/plugins/attachments/views.py
+++ b/src/wiki/plugins/attachments/views.py
@@ -386,7 +386,7 @@ class AttachmentSearchView(ArticleMixin, ListView):
                 Q(original_filename__contains=self.query) |
                 Q(current_revision__description__contains=self.query) |
                 Q(article__current_revision__title__contains=self.query))
-        return qs
+        return qs.order_by('original_filename')
 
     def get_context_data(self, **kwargs):
         # Is this a bit of a hack? Use better inheritance?

--- a/src/wiki/plugins/images/views.py
+++ b/src/wiki/plugins/images/views.py
@@ -41,7 +41,7 @@ class ImageView(ArticleMixin, ListView):
                 article=self.article,
                 current_revision__deleted=False)
         images.select_related()
-        return images
+        return images.order_by('-current_revision__imagerevision__created')
 
     def get_context_data(self, **kwargs):
         kwargs.update(ArticleMixin.get_context_data(self, **kwargs))

--- a/src/wiki/views/article.py
+++ b/src/wiki/views/article.py
@@ -686,7 +686,7 @@ class SearchView(ListView):
 
     def get_queryset(self):
         if not self.query:
-            return models.Article.objects.none()
+            return models.Article.objects.none().order_by('-current_revision__created')
         articles = models.Article.objects.filter(
             Q(current_revision__title__icontains=self.query) |
             Q(current_revision__content__icontains=self.query))
@@ -694,7 +694,7 @@ class SearchView(ListView):
                 models.URLPath.root().article,
                 self.request.user):
             articles = articles.active().can_read(self.request.user)
-        return articles
+        return articles.order_by('-current_revision__created')
 
     def get_context_data(self, **kwargs):
         kwargs = super(SearchView, self).get_context_data(**kwargs)


### PR DESCRIPTION
When providing a list of results these results should be sorted to give
consistent results. Order search results and images by the time they
were changed and attachments by there name.

This fixes the Django 1.11

    UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class '...'> QuerySet.

warning.