### PR TITLE
Added __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ virtualenv
 # text editors
 *~
 *.swp
+
+__pycache__


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-3147/ `__pycache__` overlaps with `*.pyc`, but I don't think it hurts to be explicit in `.gitignore`.