### PR TITLE
Don't import absolut_import, it's been optional since Python 2.5

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 import inspect
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 
 import os
 import sys

--- a/src/wiki/admin.py
+++ b/src/wiki/admin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import forms
 from django.contrib import admin

--- a/src/wiki/apps.py
+++ b/src/wiki/apps.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import bleach
 

--- a/src/wiki/core/compat.py
+++ b/src/wiki/core/compat.py
@@ -1,6 +1,6 @@
 """Abstraction layer to deal with Django related changes in order to keep
 compatibility with several Django versions simultaneously."""
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings as django_settings
 

--- a/src/wiki/core/diff.py
+++ b/src/wiki/core/diff.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import difflib
 

--- a/src/wiki/core/http.py
+++ b/src/wiki/core/http.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import mimetypes
 import os

--- a/src/wiki/core/markdown/__init__.py
+++ b/src/wiki/core/markdown/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import bleach
 import markdown

--- a/src/wiki/core/markdown/mdx/previewlinks.py
+++ b/src/wiki/core/markdown/mdx/previewlinks.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import markdown
 from markdown.treeprocessors import Treeprocessor

--- a/src/wiki/core/markdown/mdx/responsivetable.py
+++ b/src/wiki/core/markdown/mdx/responsivetable.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import markdown
 from markdown.treeprocessors import Treeprocessor

--- a/src/wiki/core/permissions.py
+++ b/src/wiki/core/permissions.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from wiki.conf import settings
 

--- a/src/wiki/core/plugins/base.py
+++ b/src/wiki/core/plugins/base.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import forms
 from django.utils.translation import ugettext as _

--- a/src/wiki/core/plugins/loader.py
+++ b/src/wiki/core/plugins/loader.py
@@ -5,7 +5,7 @@ https://github.com/ojii/django-load.
 
 Thanks for the technique!
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 from importlib import import_module
 

--- a/src/wiki/core/plugins/registry.py
+++ b/src/wiki/core/plugins/registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from importlib import import_module
 

--- a/src/wiki/core/utils.py
+++ b/src/wiki/core/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import json
 from importlib import import_module

--- a/src/wiki/decorators.py
+++ b/src/wiki/decorators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from functools import wraps
 

--- a/src/wiki/editors/base.py
+++ b/src/wiki/editors/base.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import forms
 

--- a/src/wiki/editors/markitup.py
+++ b/src/wiki/editors/markitup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import forms
 from django.forms.utils import flatatt

--- a/src/wiki/forms.py
+++ b/src/wiki/forms.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import random
 import string

--- a/src/wiki/managers.py
+++ b/src/wiki/managers.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import django
 from django.db import models

--- a/src/wiki/models/article.py
+++ b/src/wiki/models/article.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType

--- a/src/wiki/models/pluginbase.py
+++ b/src/wiki/models/pluginbase.py
@@ -19,7 +19,7 @@ There are three kinds of plugin base models:
 
 
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.db import models
 from django.db.models import signals

--- a/src/wiki/models/urlpath.py
+++ b/src/wiki/models/urlpath.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 import logging
 import warnings

--- a/src/wiki/plugins/attachments/admin.py
+++ b/src/wiki/plugins/attachments/admin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.contrib import admin
 

--- a/src/wiki/plugins/attachments/forms.py
+++ b/src/wiki/plugins/attachments/forms.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import tempfile
 import zipfile

--- a/src/wiki/plugins/attachments/markdown_extensions.py
+++ b/src/wiki/plugins/attachments/markdown_extensions.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import re
 

--- a/src/wiki/plugins/attachments/models.py
+++ b/src/wiki/plugins/attachments/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 import os
 

--- a/src/wiki/plugins/attachments/settings.py
+++ b/src/wiki/plugins/attachments/settings.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured

--- a/src/wiki/plugins/attachments/urls.py
+++ b/src/wiki/plugins/attachments/urls.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf.urls import url
 from wiki.plugins.attachments import views

--- a/src/wiki/plugins/attachments/views.py
+++ b/src/wiki/plugins/attachments/views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist

--- a/src/wiki/plugins/attachments/wiki_plugin.py
+++ b/src/wiki/plugins/attachments/wiki_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf.urls import include, url
 from django.utils.translation import ugettext as _

--- a/src/wiki/plugins/globalhistory/settings.py
+++ b/src/wiki/plugins/globalhistory/settings.py
@@ -1,3 +1,3 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 SLUG = 'globalhistory'

--- a/src/wiki/plugins/globalhistory/views.py
+++ b/src/wiki/plugins/globalhistory/views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.contrib.auth.decorators import login_required
 from django.db.models import F

--- a/src/wiki/plugins/globalhistory/wiki_plugin.py
+++ b/src/wiki/plugins/globalhistory/wiki_plugin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf.urls import url
 from wiki.core.plugins import registry

--- a/src/wiki/plugins/haystack/search_indexes.py
+++ b/src/wiki/plugins/haystack/search_indexes.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from haystack import indexes
 from wiki import models

--- a/src/wiki/plugins/haystack/views.py
+++ b/src/wiki/plugins/haystack/views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from haystack.backends import SQ
 from haystack.inputs import AutoQuery

--- a/src/wiki/plugins/help/wiki_plugin.py
+++ b/src/wiki/plugins/help/wiki_plugin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.utils.translation import ugettext as _
 from wiki.core.plugins import registry

--- a/src/wiki/plugins/images/admin.py
+++ b/src/wiki/plugins/images/admin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import forms
 from django.contrib import admin

--- a/src/wiki/plugins/images/forms.py
+++ b/src/wiki/plugins/images/forms.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _

--- a/src/wiki/plugins/images/markdown_extensions.py
+++ b/src/wiki/plugins/images/markdown_extensions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import re
 

--- a/src/wiki/plugins/images/models.py
+++ b/src/wiki/plugins/images/models.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import os.path
 

--- a/src/wiki/plugins/images/settings.py
+++ b/src/wiki/plugins/images/settings.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings as django_settings
 from wiki.conf import settings as wiki_settings

--- a/src/wiki/plugins/images/templatetags/wiki_images_tags.py
+++ b/src/wiki/plugins/images/templatetags/wiki_images_tags.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import template
 from wiki.plugins.images import models, settings

--- a/src/wiki/plugins/images/views.py
+++ b/src/wiki/plugins/images/views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import logging
 

--- a/src/wiki/plugins/images/wiki_plugin.py
+++ b/src/wiki/plugins/images/wiki_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf.urls import url
 from django.utils.translation import ugettext as _

--- a/src/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/src/wiki/plugins/links/mdx/djangowikilinks.py
@@ -19,7 +19,7 @@ Dependencies:
 * [Python 2.3+](http://python.org)
 * [Markdown 2.0+](http://www.freewisdom.org/projects/python-markdown/)
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from os import path as os_path
 

--- a/src/wiki/plugins/links/mdx/urlize.py
+++ b/src/wiki/plugins/links/mdx/urlize.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import re
 

--- a/src/wiki/plugins/links/settings.py
+++ b/src/wiki/plugins/links/settings.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings as django_settings
 

--- a/src/wiki/plugins/links/views.py
+++ b/src/wiki/plugins/links/views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.utils.decorators import method_decorator
 from django.views.generic.base import View

--- a/src/wiki/plugins/links/wiki_plugin.py
+++ b/src/wiki/plugins/links/wiki_plugin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 # -*- coding: utf-8 -*-
 from django.conf.urls import url

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import re
 

--- a/src/wiki/plugins/macros/mdx/toc.py
+++ b/src/wiki/plugins/macros/mdx/toc.py
@@ -21,7 +21,7 @@ SO WE AN JUST DEPEND ON THAT!
 
 
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import re
 import unicodedata

--- a/src/wiki/plugins/macros/mdx/wikilinks.py
+++ b/src/wiki/plugins/macros/mdx/wikilinks.py
@@ -2,7 +2,7 @@
 """
 Extend the shipped Markdown extension 'wikilinks'
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import re
 

--- a/src/wiki/plugins/macros/settings.py
+++ b/src/wiki/plugins/macros/settings.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings as django_settings
 

--- a/src/wiki/plugins/macros/templatetags/wiki_macro_tags.py
+++ b/src/wiki/plugins/macros/templatetags/wiki_macro_tags.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import template
 from wiki.plugins.macros import settings

--- a/src/wiki/plugins/macros/wiki_plugin.py
+++ b/src/wiki/plugins/macros/wiki_plugin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.utils.translation import ugettext as _
 from wiki.core.plugins import registry

--- a/src/wiki/plugins/notifications/forms.py
+++ b/src/wiki/plugins/notifications/forms.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django import forms
 from django.contrib.contenttypes.models import ContentType

--- a/src/wiki/plugins/notifications/models.py
+++ b/src/wiki/plugins/notifications/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
 from django.db import models

--- a/src/wiki/plugins/notifications/settings.py
+++ b/src/wiki/plugins/notifications/settings.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 
 # Deprecated

--- a/src/wiki/plugins/notifications/util.py
+++ b/src/wiki/plugins/notifications/util.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.utils.translation import ugettext as _
 

--- a/src/wiki/plugins/notifications/views.py
+++ b/src/wiki/plugins/notifications/views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required

--- a/src/wiki/plugins/notifications/wiki_plugin.py
+++ b/src/wiki/plugins/notifications/wiki_plugin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf.urls import url
 from wiki.core.plugins import registry

--- a/src/wiki/templatetags/wiki_tags.py
+++ b/src/wiki/templatetags/wiki_tags.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import re
 

--- a/src/wiki/urls.py
+++ b/src/wiki/urls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf.urls import include, url
 from wiki.conf import settings

--- a/src/wiki/views/accounts.py
+++ b/src/wiki/views/accounts.py
@@ -10,7 +10,7 @@ SETTINGS.LOGIN_URL
 SETTINGS.LOGOUT_URL
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings as django_settings
 from django.contrib import messages

--- a/src/wiki/views/article.py
+++ b/src/wiki/views/article.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import difflib
 import logging

--- a/src/wiki/views/mixins.py
+++ b/src/wiki/views/mixins.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import logging
 

--- a/testproject/manage.py
+++ b/testproject/manage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/testproject/testproject/settings/codehilite.py
+++ b/testproject/testproject/settings/codehilite.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from testproject.settings import *
 from testproject.settings.local import *

--- a/testproject/testproject/settings/customauthuser.py
+++ b/testproject/testproject/settings/customauthuser.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import os  # noqa @UnusedImport
 

--- a/testproject/testproject/settings/haystack.py
+++ b/testproject/testproject/settings/haystack.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from .base import *  # noqa @UnusedWildImport
 

--- a/testproject/testproject/settings/sendfile.py
+++ b/testproject/testproject/settings/sendfile.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from .base import *  # noqa @UnusedWildImport
 

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url

--- a/testproject/testproject/wsgi.py
+++ b/testproject/testproject/wsgi.py
@@ -13,7 +13,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import os
 import unittest

--- a/tests/core/test_accounts.py
+++ b/tests/core/test_accounts.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 
 from django.conf import settings as django_settings

--- a/tests/core/test_basic.py
+++ b/tests/core/test_basic.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 from django.test import TestCase
 

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/tests/core/test_managers.py
+++ b/tests/core/test_managers.py
@@ -4,7 +4,7 @@ because the pattern of building them is different from Django
 1.5 to 1.6 to 1.7 so there will be 3 patterns in play at the
 same time.
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 from wiki.models import Article, URLPath
 from wiki.plugins.attachments.models import Attachment

--- a/tests/core/test_markdown.py
+++ b/tests/core/test_markdown.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import markdown
 from django.test import TestCase

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.apps import apps
 from django.conf.urls import url

--- a/tests/core/test_template_filters.py
+++ b/tests/core/test_template_filters.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.contrib.auth import get_user_model
 from wiki.models import Article, ArticleRevision

--- a/tests/core/test_template_tags.py
+++ b/tests/core/test_template_tags.py
@@ -2,7 +2,7 @@
 Almost all test cases covers both tag calling and template using.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 from django.conf import settings as django_settings
 from django.contrib.contenttypes.models import ContentType

--- a/tests/core/test_urls.py
+++ b/tests/core/test_urls.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf.urls import url
 from django.contrib.auth import get_user_model

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import print_function, unicode_literals
 
 import pprint
 

--- a/tests/plugins/attachments/test_commands.py
+++ b/tests/plugins/attachments/test_commands.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import os
 import tempfile

--- a/tests/plugins/links/test_links.py
+++ b/tests/plugins/links/test_links.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import markdown
 from django.core.urlresolvers import reverse_lazy

--- a/tests/plugins/macros/test_toc.py
+++ b/tests/plugins/macros/test_toc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 import markdown
 from django.test import TestCase

--- a/tests/testdata/urls.py
+++ b/tests/testdata/urls.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0328/ only mentions Python pre 2.7