### PR TITLE
Allow the HTML tag <sup>.

### DIFF
--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -63,6 +63,7 @@ _default_tag_whitelists = bleach.ALLOWED_TAGS + [
     'img',
     'pre',
     'span',
+    'sup',
     'table',
     'thead',
     'tbody',


### PR DESCRIPTION
The by default active footnote extension uses the \<sup> tag for
rendering the footnode. \<sup> needs to be allowed for that.

This fixes #749.
