### PR TITLE
Fixed alignment of the search button to the search input field.

### DIFF
--- a/src/wiki/templates/wiki/search.html
+++ b/src/wiki/templates/wiki/search.html
@@ -11,12 +11,12 @@
 <form class="form-search directory-toolbar">
 <p class="lead">
   <div class="pull-right">
+    {% if urlpath %}
+      {% trans "Searching in" %} {{ urlpath.article }}
+    {% else %}
+      {% trans "Searching whole wiki" %}
+    {% endif %}
     <div class="input-group">
-      {% if urlpath %}
-        <p>{% trans "Searching in" %} {{ urlpath.article }}</p>
-      {% else %}
-        <p>{% trans "Searching whole wiki" %}</p>
-      {% endif %}
       <input type="search" class="form-control search-query" name="q" value="{{ search_query }}" />
       <span class="input-group-btn">
         <button class="btn btn-default" type="submit">


### PR DESCRIPTION
Since the addition of the "Searching in.../Searching whole..." label on the search
page the alignment of the search button compared to the search input field is off,
at least under Firefox. This patch moves the label out of the input-group, so that
the button and the input field are correctly aligned again.

Screen shot before (Firefox 57 under Linux):
![image](https://user-images.githubusercontent.com/27075192/34468445-0cf887f0-eed7-11e7-9e7e-bc9f69152644.png)

Screen shot after (Firefox 57 under Linux):
![image](https://user-images.githubusercontent.com/27075192/34468448-141d9c6e-eed7-11e7-857c-63c0248cb1a2.png)
