### PR TITLE
Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 env:
   - LINT="yes"
   - DJANGO="1.11"
+  - DJANGO="2.0"
 
 matrix:
   exclude:

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ def get_path(fname):
 
 
 install_requirements = [
-    "Django>=1.11,<2.0",
+    "Django>=1.11,<2.1",
     "bleach>=1.5,<2",
     "Pillow",
-    "django-nyt>=1.0,<1.1",
-    "django-mptt>=0.8.6,<0.9",
+    "django-nyt>=1.1b1,<1.2",
+    "django-mptt>=0.9,<0.10",
     "django-sekizai>=0.10",
     "sorl-thumbnail>=12,<13",
     "Markdown>=2.6,<2.7",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+def hacks():
+    from django.test import testcases
+    if not hasattr(testcases, "WSGIServer"):
+        # django-functest: patch django until is released a new version with
+        # https://github.com/django-functest/django-functest/pull/14 merged
+        from django.core.servers.basehttp import WSGIServer
+        testcases.WSGIServer = WSGIServer
+
+
+hacks()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Ensure you add to .travis.yml if you add here, using `tox -l`
-envlist = {py34,py35,py36}-django{111},lint
+envlist = {py34,py35,py36}-django{111,20},lint
 
 
 [travis]
@@ -12,6 +12,7 @@ python =
 [travis:env]
 DJANGO =
   1.11: django111
+  2.0: django20
 LINT =
   yes: lint
 
@@ -35,6 +36,7 @@ usedevelop = false
 deps =
   .[test]
   django111: Django>=1.11,<2.0
+  django20: Django>=2.0,<2.1
 
 basepython =
   py34: python3.4


### PR DESCRIPTION
I'm testing django-wiki, and I need django 2 support :)
It needs https://github.com/benjaoming/django-nyt/pull/55 because I cannot monkey patch as I've done for django-mptt (already django 2 compatible on master) or django-functest (https://github.com/django-functest/django-functest/pull/14)