### PR TITLE
Added apps config

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -75,7 +75,7 @@ maintain the order due to database relational constraints:
     'wiki.plugins.attachments.apps.AttachmentsConfig',
     'wiki.plugins.notifications.apps.NotificationsConfig',
     'wiki.plugins.images.apps.ImagesConfig',
-    'wiki.plugins.macros',
+    'wiki.plugins.macros.apps.MacrosConfig',
 
 
 Database

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,7 +74,7 @@ maintain the order due to database relational constraints:
     'wiki.apps.WikiConfig',
     'wiki.plugins.attachments',
     'wiki.plugins.notifications.apps.NotificationsConfig',
-    'wiki.plugins.images',
+    'wiki.plugins.images.apps.ImagesConfig',
     'wiki.plugins.macros',
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,7 +72,7 @@ maintain the order due to database relational constraints:
     'sekizai',
     'sorl.thumbnail',
     'wiki.apps.WikiConfig',
-    'wiki.plugins.attachments',
+    'wiki.plugins.attachments.apps.AttachmentsConfig',
     'wiki.plugins.notifications.apps.NotificationsConfig',
     'wiki.plugins.images.apps.ImagesConfig',
     'wiki.plugins.macros',

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,7 +71,7 @@ maintain the order due to database relational constraints:
     'mptt',
     'sekizai',
     'sorl.thumbnail',
-    'wiki',
+    'wiki.apps.WikiConfig',
     'wiki.plugins.attachments',
     'wiki.plugins.notifications',
     'wiki.plugins.images',

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -73,7 +73,7 @@ maintain the order due to database relational constraints:
     'sorl.thumbnail',
     'wiki.apps.WikiConfig',
     'wiki.plugins.attachments',
-    'wiki.plugins.notifications',
+    'wiki.plugins.notifications.apps.NotificationsConfig',
     'wiki.plugins.images',
     'wiki.plugins.macros',
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -9,6 +9,7 @@ enable/disable the core plugins:
 -  ``'wiki.plugins.help.apps.HelpConfig'``
 -  ``'wiki.plugins.images.apps.ImagesConfig'``
 -  ``'wiki.plugins.links.apps.LinksConfig'``
+-  ``'wiki.plugins.macros.apps.MacrosConfig'``
 -  ``'wiki.plugins.notifications.apps.NotificationsConfig'``
 
 The notifications plugin is mandatory for an out-of-the-box installation. You

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -8,6 +8,7 @@ enable/disable the core plugins:
 -  ``'wiki.plugins.globalhistory.apps.GlobalHistoryConfig'``
 -  ``'wiki.plugins.help.apps.HelpConfig'``
 -  ``'wiki.plugins.images.apps.ImagesConfig'``
+-  ``'wiki.plugins.links.apps.LinksConfig'``
 -  ``'wiki.plugins.notifications.apps.NotificationsConfig'``
 
 The notifications plugin is mandatory for an out-of-the-box installation. You

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -6,6 +6,7 @@ enable/disable the core plugins:
 
 -  ``'wiki.plugins.attachments.apps.AttachmentsConfig'``
 -  ``'wiki.plugins.globalhistory.apps.GlobalHistoryConfig'``
+-  ``'wiki.plugins.help.apps.HelpConfig'``
 -  ``'wiki.plugins.images.apps.ImagesConfig'``
 -  ``'wiki.plugins.notifications.apps.NotificationsConfig'``
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -5,7 +5,7 @@ Add/remove the following to your ``settings.INSTALLED_APPS`` to
 enable/disable the core plugins:
 
 -  ``'wiki.plugins.attachments'``
--  ``'wiki.plugins.images'``
+-  ``'wiki.plugins.images.apps.ImagesConfig'``
 -  ``'wiki.plugins.globalhistory'``
 -  ``'wiki.plugins.notifications.apps.NotificationsConfig'``
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -6,8 +6,8 @@ enable/disable the core plugins:
 
 -  ``'wiki.plugins.attachments'``
 -  ``'wiki.plugins.images'``
--  ``'wiki.plugins.notifications'``
 -  ``'wiki.plugins.globalhistory'``
+-  ``'wiki.plugins.notifications.apps.NotificationsConfig'``
 
 The notifications plugin is mandatory for an out-of-the-box installation. You
 can safely remove it from ``INSTALLED_APPS`` if you also override the

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -4,7 +4,7 @@ Plugins
 Add/remove the following to your ``settings.INSTALLED_APPS`` to
 enable/disable the core plugins:
 
--  ``'wiki.plugins.attachments'``
+-  ``'wiki.plugins.attachments.apps.AttachmentsConfig'``
 -  ``'wiki.plugins.images.apps.ImagesConfig'``
 -  ``'wiki.plugins.globalhistory'``
 -  ``'wiki.plugins.notifications.apps.NotificationsConfig'``

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -5,8 +5,8 @@ Add/remove the following to your ``settings.INSTALLED_APPS`` to
 enable/disable the core plugins:
 
 -  ``'wiki.plugins.attachments.apps.AttachmentsConfig'``
+-  ``'wiki.plugins.globalhistory.apps.GlobalHistoryConfig'``
 -  ``'wiki.plugins.images.apps.ImagesConfig'``
--  ``'wiki.plugins.globalhistory'``
 -  ``'wiki.plugins.notifications.apps.NotificationsConfig'``
 
 The notifications plugin is mandatory for an out-of-the-box installation. You

--- a/src/wiki/apps.py
+++ b/src/wiki/apps.py
@@ -7,9 +7,3 @@ from django.utils.translation import ugettext_lazy as _
 class WikiConfig(AppConfig):
     name = "wiki"
     verbose_name = _("Wiki")
-
-
-class AttachmentsConfig(AppConfig):
-    name = 'wiki.plugins.attachments'
-    verbose_name = _("Wiki attachments")
-    label = 'wiki_attachments'

--- a/src/wiki/apps.py
+++ b/src/wiki/apps.py
@@ -9,12 +9,6 @@ class WikiConfig(AppConfig):
     verbose_name = _("Wiki")
 
 
-class ImagesConfig(AppConfig):
-    name = 'wiki.plugins.images'
-    verbose_name = _("Wiki images")
-    label = 'wiki_images'
-
-
 class AttachmentsConfig(AppConfig):
     name = 'wiki.plugins.attachments'
     verbose_name = _("Wiki attachments")

--- a/src/wiki/apps.py
+++ b/src/wiki/apps.py
@@ -9,12 +9,6 @@ class WikiConfig(AppConfig):
     verbose_name = _("Wiki")
 
 
-class NotifcationsConfig(AppConfig):
-    name = 'wiki.plugins.notifications'
-    verbose_name = _("Wiki notifications")
-    label = 'wiki_notifications'
-
-
 class ImagesConfig(AppConfig):
     name = 'wiki.plugins.images'
     verbose_name = _("Wiki images")

--- a/src/wiki/apps.py
+++ b/src/wiki/apps.py
@@ -4,6 +4,11 @@ from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 
 
+class WikiConfig(AppConfig):
+    name = "wiki"
+    verbose_name = _("Wiki")
+
+
 class NotifcationsConfig(AppConfig):
     name = 'wiki.plugins.notifications'
     verbose_name = _("Wiki notifications")

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import bleach
 
+from django.apps import apps
 from django.conf import settings as django_settings
 from django.contrib.messages import constants as messages
 from django.core.files.storage import default_storage
@@ -272,7 +273,7 @@ SEARCH_VIEW = getattr(
     django_settings,
     'WIKI_SEARCH_VIEW',
     'wiki.views.article.SearchView'
-    if 'wiki.plugins.haystack' not in django_settings.INSTALLED_APPS
+    if not apps.is_installed('wiki.plugins.haystack')
     else
     'wiki.plugins.haystack.views.HaystackSearchView'
 )

--- a/src/wiki/core/plugins/loader.py
+++ b/src/wiki/core/plugins/loader.py
@@ -1,44 +1,8 @@
 # -*- coding: utf-8 -*-
-"""
-Credits to ojii, functions get_module and load are from:
-https://github.com/ojii/django-load.
-
-Thanks for the technique!
-"""
 from __future__ import print_function, unicode_literals
 
-from importlib import import_module
-
-from django.conf import settings
-
-
-def get_module(app, modname, verbose, failfast):
-    """
-    Internal function to load a module from a single app.
-    """
-    module_name = '%s.%s' % (app, modname)
-    try:
-        module = import_module(module_name)
-    except ImportError as e:
-        if failfast:
-            raise e
-        elif verbose:
-            print("Could not load %r from %r: %s" % (modname, app, e))
-        return None
-    if verbose:
-        print("Loaded %r from %r" % (modname, app))
-    return module
-
-
-def load(modname, verbose=False, failfast=False):
-    """
-    Loads all modules with name 'modname' from all installed apps.
-    If verbose is True, debug information will be printed to stdout.
-    If failfast is True, import errors will not be surpressed.
-    """
-    for app in settings.INSTALLED_APPS:
-        get_module(app, modname, verbose, failfast)
+from django.utils.module_loading import autodiscover_modules
 
 
 def load_wiki_plugins():
-    load('wiki_plugin', verbose=False, failfast=False)
+    autodiscover_modules('wiki_plugin')

--- a/src/wiki/models/__init__.py
+++ b/src/wiki/models/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from django.apps import apps
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from six import string_types, text_type
@@ -20,24 +21,24 @@ from django.utils.functional import lazy
 # Configuration stuff
 ######################
 
-if 'mptt' not in django_settings.INSTALLED_APPS:
+if not apps.is_installed('mptt'):
     raise ImproperlyConfigured('django-wiki: needs mptt in INSTALLED_APPS')
 
-if 'sekizai' not in django_settings.INSTALLED_APPS:
+if not apps.is_installed('sekizai'):
     raise ImproperlyConfigured('django-wiki: needs sekizai in INSTALLED_APPS')
 
-# if not 'django_nyt' in django_settings.INSTALLED_APPS:
+# if not apps.is_installed('django_nyt'):
 #    raise ImproperlyConfigured('django-wiki: needs django_nyt in INSTALLED_APPS')
 
-if 'django.contrib.humanize' not in django_settings.INSTALLED_APPS:
+if not apps.is_installed('django.contrib.humanize'):
     raise ImproperlyConfigured(
         'django-wiki: needs django.contrib.humanize in INSTALLED_APPS')
 
-if 'django.contrib.contenttypes' not in django_settings.INSTALLED_APPS:
+if not apps.is_installed('django.contrib.contenttypes'):
     raise ImproperlyConfigured(
         'django-wiki: needs django.contrib.contenttypes in INSTALLED_APPS')
 
-if 'django.contrib.sites' not in django_settings.INSTALLED_APPS:
+if not apps.is_installed('django.contrib.sites'):
     raise ImproperlyConfigured(
         'django-wiki: needs django.contrib.sites in INSTALLED_APPS')
 
@@ -59,7 +60,7 @@ if not any(s in TEMPLATE_CONTEXT_PROCESSORS for s in ['django.core.context_proce
     raise ImproperlyConfigured(
         'django-wiki: needs django.core.context_processors.request or django.template.context_processors.request in TEMPLATE_CONTEXT_PROCESSORS')
 
-if 'django_notify' in django_settings.INSTALLED_APPS:
+if apps.is_installed('django_notify'):
     raise ImproperlyConfigured(
         'django-wiki: You need to change from django_notify to django_nyt in INSTALLED_APPS and your urlconfig.')
 

--- a/src/wiki/plugins/attachments/__init__.py
+++ b/src/wiki/plugins/attachments/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import unicode_literals
-default_app_config = 'wiki.apps.AttachmentsConfig'
+
+default_app_config = 'wiki.plugins.attachments.apps.AttachmentsConfig'

--- a/src/wiki/plugins/attachments/apps.py
+++ b/src/wiki/plugins/attachments/apps.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class AttachmentsConfig(AppConfig):
+    name = 'wiki.plugins.attachments'
+    verbose_name = _("Wiki attachments")
+    label = 'wiki_attachments'

--- a/src/wiki/plugins/globalhistory/__init__.py
+++ b/src/wiki/plugins/globalhistory/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import unicode_literals
+
+default_app_config = 'wiki.plugins.globalhistory.apps.GlobalHistoryConfig'

--- a/src/wiki/plugins/globalhistory/apps.py
+++ b/src/wiki/plugins/globalhistory/apps.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class GlobalHistoryConfig(AppConfig):
+    name = 'wiki.plugins.globalhistory'
+    verbose_name = _("Wiki Global History")
+    label = 'wiki_globalhistory'

--- a/src/wiki/plugins/help/__init__.py
+++ b/src/wiki/plugins/help/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import unicode_literals
+
+default_app_config = 'wiki.plugins.help.apps.HelpConfig'

--- a/src/wiki/plugins/help/apps.py
+++ b/src/wiki/plugins/help/apps.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class HelpConfig(AppConfig):
+    name = 'wiki.plugins.help'
+    verbose_name = _("Wiki help")
+    label = 'wiki_help'

--- a/src/wiki/plugins/images/__init__.py
+++ b/src/wiki/plugins/images/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import unicode_literals
-default_app_config = 'wiki.apps.ImagesConfig'
+
+default_app_config = 'wiki.plugins.images.apps.ImagesConfig'

--- a/src/wiki/plugins/images/apps.py
+++ b/src/wiki/plugins/images/apps.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class ImagesConfig(AppConfig):
+    name = 'wiki.plugins.images'
+    verbose_name = _("Wiki images")
+    label = 'wiki_images'

--- a/src/wiki/plugins/images/models.py
+++ b/src/wiki/plugins/images/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os.path
 
+from django.apps import apps
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
@@ -13,7 +14,7 @@ from wiki.models.pluginbase import RevisionPlugin, RevisionPluginRevision
 
 from . import settings
 
-if "sorl.thumbnail" not in django_settings.INSTALLED_APPS:
+if not apps.is_installed("sorl.thumbnail"):
     raise ImproperlyConfigured(
         'wiki.plugins.images: needs sorl.thumbnail in INSTALLED_APPS')
 

--- a/src/wiki/plugins/links/__init__.py
+++ b/src/wiki/plugins/links/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import unicode_literals
+
+default_app_config = 'wiki.plugins.links.apps.LinksConfig'

--- a/src/wiki/plugins/links/apps.py
+++ b/src/wiki/plugins/links/apps.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class LinksConfig(AppConfig):
+    name = 'wiki.plugins.links'
+    verbose_name = _("Wiki links")
+    label = 'wiki_links'

--- a/src/wiki/plugins/macros/__init__.py
+++ b/src/wiki/plugins/macros/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import unicode_literals
+
+default_app_config = 'wiki.plugins.macros.apps.MacrosConfig'

--- a/src/wiki/plugins/macros/apps.py
+++ b/src/wiki/plugins/macros/apps.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class MacrosConfig(AppConfig):
+    name = 'wiki.plugins.macros'
+    verbose_name = _("Wiki macros")
+    label = 'wiki_macros'

--- a/src/wiki/plugins/notifications/__init__.py
+++ b/src/wiki/plugins/notifications/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import unicode_literals
-default_app_config = 'wiki.apps.NotifcationsConfig'
+
+default_app_config = 'wiki.plugins.notifications.apps.NotificationsConfig'

--- a/src/wiki/plugins/notifications/apps.py
+++ b/src/wiki/plugins/notifications/apps.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class NotificationsConfig(AppConfig):
+    name = 'wiki.plugins.notifications'
+    verbose_name = _("Wiki notifications")
+    label = 'wiki_notifications'

--- a/src/wiki/templatetags/wiki_tags.py
+++ b/src/wiki/templatetags/wiki_tags.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import re
 
+from django.apps import apps
 from django import template
 from django.conf import settings as django_settings
 from django.contrib.contenttypes.models import ContentType
@@ -203,7 +204,7 @@ def plugin_enabled(plugin_name):
     :param: plugin_name: String specifying the full name of the plugin, e.g.
                          'wiki.plugins.attachments'
     """
-    return plugin_name in django_settings.INSTALLED_APPS
+    return apps.is_installed(plugin_name)
 
 
 @register.filter

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -30,7 +30,7 @@ INSTALLED_APPS = [
     'mptt',
     'sekizai',
     'sorl.thumbnail',
-    'wiki',
+    'wiki.apps.WikiConfig',
     'wiki.plugins.attachments',
     'wiki.plugins.notifications',
     'wiki.plugins.images',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -31,7 +31,7 @@ INSTALLED_APPS = [
     'sekizai',
     'sorl.thumbnail',
     'wiki.apps.WikiConfig',
-    'wiki.plugins.attachments',
+    'wiki.plugins.attachments.apps.AttachmentsConfig',
     'wiki.plugins.notifications.apps.NotificationsConfig',
     'wiki.plugins.images.apps.ImagesConfig',
     'wiki.plugins.macros',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -33,7 +33,7 @@ INSTALLED_APPS = [
     'wiki.apps.WikiConfig',
     'wiki.plugins.attachments',
     'wiki.plugins.notifications.apps.NotificationsConfig',
-    'wiki.plugins.images',
+    'wiki.plugins.images.apps.ImagesConfig',
     'wiki.plugins.macros',
     'wiki.plugins.globalhistory',
 ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     'sorl.thumbnail',
     'wiki.apps.WikiConfig',
     'wiki.plugins.attachments',
-    'wiki.plugins.notifications',
+    'wiki.plugins.notifications.apps.NotificationsConfig',
     'wiki.plugins.images',
     'wiki.plugins.macros',
     'wiki.plugins.globalhistory',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -34,7 +34,7 @@ INSTALLED_APPS = [
     'wiki.plugins.attachments.apps.AttachmentsConfig',
     'wiki.plugins.notifications.apps.NotificationsConfig',
     'wiki.plugins.images.apps.ImagesConfig',
-    'wiki.plugins.macros',
+    'wiki.plugins.macros.apps.MacrosConfig',
     'wiki.plugins.globalhistory.apps.GlobalHistoryConfig',
 ]
 MIDDLEWARE_CLASSES = [

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -35,7 +35,7 @@ INSTALLED_APPS = [
     'wiki.plugins.notifications.apps.NotificationsConfig',
     'wiki.plugins.images.apps.ImagesConfig',
     'wiki.plugins.macros',
-    'wiki.plugins.globalhistory',
+    'wiki.plugins.globalhistory.apps.GlobalHistoryConfig',
 ]
 MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Added app config for django-wiki and its default plugins and use the django apps machinery.
I've kept an import for existing plugins config in main apps.py.

(pr taken out from https://github.com/django-wiki/django-wiki/pull/755)