### PR TITLE
Explicit all on_delete on ForeignKey fields

### DIFF
--- a/src/wiki/migrations/0001_initial.py
+++ b/src/wiki/migrations/0001_initial.py
@@ -42,8 +42,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(serialize=False, primary_key=True, auto_created=True, verbose_name='ID')),
                 ('object_id', models.PositiveIntegerField(verbose_name='object ID')),
                 ('is_mptt', models.BooleanField(default=False, editable=False)),
-                ('article', models.ForeignKey(to='wiki.Article')),
-                ('content_type', models.ForeignKey(related_name='content_type_set_for_articleforobject', verbose_name='content type', to='contenttypes.ContentType')),
+                ('article', models.ForeignKey(to='wiki.Article', on_delete=models.CASCADE)),
+                ('content_type', models.ForeignKey(related_name='content_type_set_for_articleforobject', verbose_name='content type', to='contenttypes.ContentType', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'Articles for object',
@@ -76,7 +76,7 @@ class Migration(migrations.Migration):
                 ('locked', models.BooleanField(default=False, verbose_name='locked')),
                 ('content', models.TextField(blank=True, verbose_name='article contents')),
                 ('title', models.CharField(max_length=512, verbose_name='article title', help_text='Each revision contains a title field that must be filled out, even if the title has not changed')),
-                ('article', models.ForeignKey(to='wiki.Article', verbose_name='article')),
+                ('article', models.ForeignKey(to='wiki.Article', verbose_name='article', on_delete=models.CASCADE)),
                 ('previous_revision', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, blank=True, to='wiki.ArticleRevision')),
                 ('user', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, blank=True, to=settings.AUTH_USER_MODEL, verbose_name='user')),
             ],
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ReusablePlugin',
             fields=[
-                ('articleplugin_ptr', models.OneToOneField(primary_key=True, parent_link=True, to='wiki.ArticlePlugin', serialize=False, auto_created=True)),
+                ('articleplugin_ptr', models.OneToOneField(primary_key=True, parent_link=True, to='wiki.ArticlePlugin', serialize=False, auto_created=True, on_delete=models.CASCADE)),
                 ('articles', models.ManyToManyField(related_name='shared_plugins_set', to='wiki.Article')),
             ],
             options={
@@ -99,7 +99,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='RevisionPlugin',
             fields=[
-                ('articleplugin_ptr', models.OneToOneField(primary_key=True, parent_link=True, to='wiki.ArticlePlugin', serialize=False, auto_created=True)),
+                ('articleplugin_ptr', models.OneToOneField(primary_key=True, parent_link=True, to='wiki.ArticlePlugin', serialize=False, auto_created=True, on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -117,7 +117,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('deleted', models.BooleanField(default=False, verbose_name='deleted')),
                 ('locked', models.BooleanField(default=False, verbose_name='locked')),
-                ('plugin', models.ForeignKey(related_name='revision_set', to='wiki.RevisionPlugin')),
+                ('plugin', models.ForeignKey(related_name='revision_set', to='wiki.RevisionPlugin', on_delete=models.CASCADE)),
                 ('previous_revision', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, blank=True, to='wiki.RevisionPluginRevision')),
                 ('user', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, blank=True, to=settings.AUTH_USER_MODEL, verbose_name='user')),
             ],
@@ -130,8 +130,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SimplePlugin',
             fields=[
-                ('articleplugin_ptr', models.OneToOneField(primary_key=True, parent_link=True, to='wiki.ArticlePlugin', serialize=False, auto_created=True)),
-                ('article_revision', models.ForeignKey(to='wiki.ArticleRevision')),
+                ('articleplugin_ptr', models.OneToOneField(primary_key=True, parent_link=True, to='wiki.ArticlePlugin', serialize=False, auto_created=True, on_delete=models.CASCADE)),
+                ('article_revision', models.ForeignKey(to='wiki.ArticleRevision', on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -163,7 +163,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='revisionplugin',
             name='current_revision',
-            field=models.OneToOneField(related_name='plugin_set', null=True, help_text='The revision being displayed for this plugin. If you need to do a roll-back, simply change the value of this field.', blank=True, to='wiki.RevisionPluginRevision', verbose_name='current revision'),
+            field=models.OneToOneField(related_name='plugin_set', null=True, help_text='The revision being displayed for this plugin. If you need to do a roll-back, simply change the value of this field.', blank=True, to='wiki.RevisionPluginRevision', verbose_name='current revision', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(
@@ -173,7 +173,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='articleplugin',
             name='article',
-            field=models.ForeignKey(to='wiki.Article', verbose_name='article'),
+            field=models.ForeignKey(to='wiki.Article', verbose_name='article', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(
@@ -183,7 +183,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='article',
             name='current_revision',
-            field=models.OneToOneField(related_name='current_set', null=True, help_text='The revision being displayed for this article. If you need to do a roll-back, simply change the value of this field.', blank=True, to='wiki.ArticleRevision', verbose_name='current revision'),
+            field=models.OneToOneField(related_name='current_set', null=True, help_text='The revision being displayed for this article. If you need to do a roll-back, simply change the value of this field.', blank=True, to='wiki.ArticleRevision', verbose_name='current revision', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/src/wiki/models/article.py
+++ b/src/wiki/models/article.py
@@ -28,6 +28,7 @@ class Article(models.Model):
     current_revision = models.OneToOneField(
         'ArticleRevision', verbose_name=_('current revision'),
         blank=True, null=True, related_name='current_set',
+        on_delete=models.SET_NULL,
         help_text=_(
             'The revision being displayed for this article. If you need to do a roll-back, simply change the value of this field.'),)
 
@@ -236,6 +237,7 @@ class ArticleForObject(models.Model):
     # Same as django.contrib.comments
     content_type = models.ForeignKey(
         ContentType,
+        on_delete=models.CASCADE,
         verbose_name=_('content type'),
         related_name="content_type_set_for_%(class)s")
     object_id = models.PositiveIntegerField(_('object ID'))

--- a/src/wiki/models/pluginbase.py
+++ b/src/wiki/models/pluginbase.py
@@ -161,6 +161,7 @@ class RevisionPlugin(ArticlePlugin):
         verbose_name=_('current revision'),
         blank=True,
         null=True,
+        on_delete=models.SET_NULL,
         related_name='plugin_set',
         help_text=_(
             'The revision being displayed for this plugin. '
@@ -202,7 +203,7 @@ class RevisionPluginRevision(BaseRevisionMixin, models.Model):
     (this class is very much copied from wiki.models.article.ArticleRevision
     """
 
-    plugin = models.ForeignKey(RevisionPlugin, related_name='revision_set')
+    plugin = models.ForeignKey(RevisionPlugin, on_delete=models.CASCADE, related_name='revision_set')
 
     class Meta:
         # Override this setting with app_label = '' in your extended model

--- a/src/wiki/models/urlpath.py
+++ b/src/wiki/models/urlpath.py
@@ -66,11 +66,12 @@ class URLPath(MPTTModel):
 
     slug = models.SlugField(verbose_name=_('slug'), null=True, blank=True,
                             max_length=SLUG_MAX_LENGTH)
-    site = models.ForeignKey(Site)
+    site = models.ForeignKey(Site, on_delete=models.CASCADE)
     parent = TreeForeignKey(
         'self',
         null=True,
         blank=True,
+        on_delete=models.SET_NULL,
         related_name='children',
         help_text=_("Position of URL path in the tree.")
     )

--- a/src/wiki/plugins/attachments/migrations/0001_initial.py
+++ b/src/wiki/plugins/attachments/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Attachment',
             fields=[
-                ('reusableplugin_ptr', models.OneToOneField(parent_link=True, serialize=False, primary_key=True, to='wiki.ReusablePlugin', auto_created=True)),
+                ('reusableplugin_ptr', models.OneToOneField(parent_link=True, serialize=False, primary_key=True, to='wiki.ReusablePlugin', auto_created=True, on_delete=models.CASCADE)),
                 ('original_filename', models.CharField(max_length=256, verbose_name='original filename', blank=True, null=True)),
             ],
             options={
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
                 ('locked', models.BooleanField(default=False, verbose_name='locked')),
                 ('file', models.FileField(max_length=255, verbose_name='file', upload_to=wiki.plugins.attachments.models.upload_path)),
                 ('description', models.TextField(blank=True)),
-                ('attachment', models.ForeignKey(to='wiki_attachments.Attachment')),
+                ('attachment', models.ForeignKey(to='wiki_attachments.Attachment', on_delete=models.CASCADE)),
                 ('previous_revision', models.ForeignKey(blank=True, on_delete=django.db.models.deletion.SET_NULL, to='wiki_attachments.AttachmentRevision', null=True)),
                 ('user', models.ForeignKey(blank=True, verbose_name='user', on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True)),
             ],
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='attachment',
             name='current_revision',
-            field=models.OneToOneField(to='wiki_attachments.AttachmentRevision', blank=True, verbose_name='current revision', related_name='current_set', help_text='The revision of this attachment currently in use (on all articles using the attachment)', null=True),
+            field=models.OneToOneField(to='wiki_attachments.AttachmentRevision', blank=True, verbose_name='current revision', related_name='current_set', help_text='The revision of this attachment currently in use (on all articles using the attachment)', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/src/wiki/plugins/attachments/models.py
+++ b/src/wiki/plugins/attachments/models.py
@@ -31,6 +31,7 @@ class Attachment(ReusablePlugin):
     current_revision = models.OneToOneField(
         'AttachmentRevision', verbose_name=_('current revision'),
         blank=True, null=True, related_name='current_set',
+        on_delete=models.SET_NULL,
         help_text=_(
             'The revision of this attachment currently in use (on all articles using the attachment)'),)
 
@@ -119,7 +120,7 @@ def upload_path(instance, filename):
 @python_2_unicode_compatible
 class AttachmentRevision(BaseRevisionMixin, models.Model):
 
-    attachment = models.ForeignKey('Attachment')
+    attachment = models.ForeignKey('Attachment', on_delete=models.CASCADE)
 
     file = models.FileField(upload_to=upload_path,  # @ReservedAssignment
                             max_length=255,

--- a/src/wiki/plugins/images/migrations/0001_initial.py
+++ b/src/wiki/plugins/images/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Image',
             fields=[
-                ('revisionplugin_ptr', models.OneToOneField(to='wiki.RevisionPlugin', primary_key=True, auto_created=True, parent_link=True, serialize=False)),
+                ('revisionplugin_ptr', models.OneToOneField(to='wiki.RevisionPlugin', primary_key=True, auto_created=True, parent_link=True, serialize=False, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'image',
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ImageRevision',
             fields=[
-                ('revisionpluginrevision_ptr', models.OneToOneField(to='wiki.RevisionPluginRevision', primary_key=True, auto_created=True, parent_link=True, serialize=False)),
+                ('revisionpluginrevision_ptr', models.OneToOneField(to='wiki.RevisionPluginRevision', primary_key=True, auto_created=True, parent_link=True, serialize=False, on_delete=models.CASCADE)),
                 ('image', models.ImageField(null=True, blank=True, height_field='height', max_length=2000, width_field='width', upload_to=wiki.plugins.images.models.upload_path)),
                 ('width', models.SmallIntegerField(null=True, blank=True)),
                 ('height', models.SmallIntegerField(null=True, blank=True)),

--- a/src/wiki/plugins/notifications/migrations/0001_initial.py
+++ b/src/wiki/plugins/notifications/migrations/0001_initial.py
@@ -15,8 +15,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ArticleSubscription',
             fields=[
-                ('articleplugin_ptr', models.OneToOneField(auto_created=True, to='wiki.ArticlePlugin', primary_key=True, parent_link=True, serialize=False)),
-                ('subscription', models.OneToOneField(to='django_nyt.Subscription')),
+                ('articleplugin_ptr', models.OneToOneField(auto_created=True, to='wiki.ArticlePlugin', primary_key=True, parent_link=True, serialize=False, on_delete=models.CASCADE)),
+                ('subscription', models.OneToOneField(to='django_nyt.Subscription', on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/src/wiki/plugins/notifications/models.py
+++ b/src/wiki/plugins/notifications/models.py
@@ -19,7 +19,7 @@ from wiki.plugins.notifications.util import get_title
 @python_2_unicode_compatible
 class ArticleSubscription(ArticlePlugin):
 
-    subscription = models.OneToOneField(Subscription)
+    subscription = models.OneToOneField(Subscription, on_delete=models.CASCADE)
 
     def __str__(self):
         title = (_("%(user)s subscribing to %(article)s (%(type)s)") %


### PR DESCRIPTION
Added missing explicit on_delete on foreign keys.

(pr taken out from https://github.com/django-wiki/django-wiki/pull/755)