### PR TITLE
Set atomic = False for AlterModelTable migrations

### DIFF
--- a/src/wiki/plugins/attachments/migrations/0002_auto_20151118_1816.py
+++ b/src/wiki/plugins/attachments/migrations/0002_auto_20151118_1816.py
@@ -6,6 +6,8 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
+    atomic = False
+
     dependencies = [
         ('wiki_attachments', '0001_initial'),
     ]

--- a/src/wiki/plugins/images/migrations/0002_auto_20151118_1811.py
+++ b/src/wiki/plugins/images/migrations/0002_auto_20151118_1811.py
@@ -6,6 +6,8 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
+    atomic = False
+
     dependencies = [
         ('wiki_images', '0001_initial'),
     ]

--- a/src/wiki/plugins/notifications/migrations/0002_auto_20151118_1811.py
+++ b/src/wiki/plugins/notifications/migrations/0002_auto_20151118_1811.py
@@ -6,6 +6,8 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
+    atomic = False
+
     dependencies = [
         ('wiki_notifications', '0001_initial'),
     ]


### PR DESCRIPTION
Add atomic flag for django >= 1.10, on django < 1.10 it does nothing.

(pr taken out from https://github.com/django-wiki/django-wiki/pull/755)