### PR TITLE
django-nyt version cap for 0.2 series

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: 97b88d9610bcc03982ddac33caba98bb2b751f5f
+    sha: 79915aa6ef4624ba66a5806381908e6a19fcc603
     hooks:
     -   id: trailing-whitespace
     -   id: flake8
@@ -9,7 +10,7 @@
     -   id: debug-statements
     -   id: end-of-file-fixer
 -   repo: git://github.com/FalconSocial/pre-commit-python-sorter
-    sha: d044ff27300a6dc8b1a56cd22552e3a810dc6f49
+    sha: b57843b0b874df1d16eb0bef00b868792cb245c2
     hooks:
     -   id: python-import-sorter
         args:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
 include COPYING
 include README.rst
 include setup.cfg
-include model_chart_wiki.pdf
-recursive-include wiki *.html *.txt *.png *.js *.css *.gif *.less *.mo *.po *.otf *.svg *.woff *.eot *.ttf
+recursive-include wiki *.html *.txt *.png *.js *.css *.gif *.less *.mo *.po *.otf *.svg *.woff *.woff2 *.eot *.ttf
 prune wiki/attachments
 # Exclude compiled version of source language, it's meaningless
 exclude wiki/locale/en/LC_MESSAGES/django.mo
+

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,12 @@ the last series with Python 2 support. Series 0.3 is in development in the
 current master branch.
 
 
+django-wiki 0.2.5
+-----------------
+
+ * Put an upper limit on django-nyt version
+
+
 django-wiki 0.2.4
 -----------------
 
@@ -132,19 +138,19 @@ django-wiki 0.1
    If you are upgrading from a previous release, please ensure that you
    pass through the 0.0.24 release because it contains the final migrations
    necessary before entering the django-wiki 0.1+ migration tree.
-   
+
    If you are using django 1.7+ and have an old installation of django-wiki
    (which should be impossible since it wouldn't run) please downgrade to 1.6
    as follows:
-   
+
    ::
-   
+
        $ pip install wiki\<0.1 --upgrade  # Latest 0.0.24 release
        $ pip install django\<1.7  # Downgrade django if necessary
        $ python manage.py migrate  # Run 0.0.24 migrations
        $ pip install wiki\<0.2 --upgrade  # Upgrade to latest 0.1 series
        $ python manage.py migrate --delete-ghost-migrations  # Run migrations again,
-                                                             # removing the (ghost) 
+                                                             # removing the (ghost)
                                                              # migrations from previous
                                                              # release
        $ # Feel free to upgrade Django again
@@ -204,7 +210,7 @@ Firstly, upgrade django-wiki through familiar steps with pip
 ::
 
     $ pip install wiki --upgrade
-   
+
 During the upgrade, notice that `django-nyt`_ is installed. This replaces the
 previously bundled django_notify and you need to make a few changes in
 your settings and urls.
@@ -269,7 +275,7 @@ Don't worry, just fake the backwards migration:
 
 ::
 
-    python manage.py migrate notifications zero --fake  
+    python manage.py migrate notifications zero --fake
 
 If you get ``relation "notifications_articlesubscription" already exists`` you
 may need to do a manual ``DROP TABLE notifications_articlesubscription;`` using
@@ -343,4 +349,3 @@ actually new features, too.
 -  Python 3 and Django 1.6 compatibility (Russell-Jones, Antonin
    Lenfant, Luke Plant, Lubimov Igor, Benjamin Bach)
 -  (and more, forgiveness asked if anyone feels left out)
-

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,9 +10,14 @@ the last series with Python 2 support. Series 0.3 is in development in the
 current master branch.
 
 
+django-wiki 0.2.4
+-----------------
 
-django-wiki 0.2.3 (unreleased)
-------------------------------
+ * Hot-fix because of missing woff2 files #625
+
+
+django-wiki 0.2.3
+-----------------
 
  * Pulled Transifex translations and pushed source translations.
  * Fix support for Py2 unicode in code blocks (Benjamin Bach) #607

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import sys
+
 from setuptools import find_packages, setup
 
 from wiki import __version__
@@ -30,7 +31,7 @@ requirements = [
     "Django>=1.8,<1.11",
     "bleach>=1.5,<2",
     "Pillow",
-    "django-nyt>=1.0b1",
+    "django-nyt>=1.0b1,<1.1",
     "six",
     "django-mptt>=0.8.6,<0.9",
     "django-sekizai>=0.10",

--- a/wiki/__init__.py
+++ b/wiki/__init__.py
@@ -19,5 +19,5 @@ from __future__ import unicode_literals
 
 from wiki.core.version import get_version
 
-VERSION = (0, 2, 3, 'final', 0)
+VERSION = (0, 2, 4, 'final', 0)
 __version__ = get_version(VERSION)

--- a/wiki/__init__.py
+++ b/wiki/__init__.py
@@ -19,5 +19,5 @@ from __future__ import unicode_literals
 
 from wiki.core.version import get_version
 
-VERSION = (0, 2, 4, 'final', 0)
+VERSION = (0, 2, 5, 'final', 0)
 __version__ = get_version(VERSION)


### PR DESCRIPTION
Seems also that a couple of changes only made it to `master`, so they're included for the release tracking branch here as well...