### PR TITLE
Small documentation fix

### DIFF
--- a/src/wiki/plugins/attachments/settings.py
+++ b/src/wiki/plugins/attachments/settings.py
@@ -48,6 +48,7 @@ UPLOAD_PATH_OBSCURIFY = getattr(
 #: some script. The extensions are case insensitive.
 #: You are asked to explicitly enter all file extensions that you want
 #: to allow. For your own safety.
+#: Note: this setting is called WIKI_ATTACHMENTS_EXTENTIONS not WIKI_ATTACHMENTS_FILE_EXTENTIONS
 FILE_EXTENSIONS = getattr(
     django_settings, 'WIKI_ATTACHMENTS_EXTENSIONS',
     ['pdf', 'doc', 'odt', 'docx', 'txt'])


### PR DESCRIPTION
The setting name does not match the expected name (dropped the "File") added this to docs and did not change the setting to preserve backward compatibility.
