### PR TITLE
Fix wrong django setting name for MARKDOWN_HTML_ATTRIBUTES

### DIFF
--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -102,7 +102,7 @@ MARKDOWN_HTML_ATTRIBUTES = _default_attribute_whitelist
 MARKDOWN_HTML_ATTRIBUTES.update(
     getattr(
         django_settings,
-        'WIKI_MARKDOWN_HTML_ATTRIBUTE_WHITELIST',
+        'WIKI_MARKDOWN_HTML_ATTRIBUTES',
         {}
     )
 )


### PR DESCRIPTION
Code fixed to match documentation.