### PR TITLE
Fix missing migrations in 0.3.0 by reverting model changes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,12 @@ The next series **0.4** will support Django 1.11 and Django 2.x and be for
 Python 3.4+.
 
 
+django-wiki 0.3.1
+-----------------
+
+* Fix error messages of missing migrations due to inconsistent change of ``on_delete`` on some model fields :url-issue:`776`
+
+
 django-wiki 0.3
 ---------------
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = [
     "Django>=1.8,<2.0",
     "bleach>=1.5,<2",
     "Pillow",
-    "django-nyt>=1.0b1,<1.1",
+    "django-nyt>=1.0,<1.1",
     "six",
     "django-mptt>=0.8.6,<0.9",
     "django-sekizai>=0.10",

--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -19,5 +19,5 @@ from __future__ import unicode_literals
 
 from wiki.core.version import get_version
 
-VERSION = (0, 3, 0, 'final', 0)
+VERSION = (0, 3, 1, 'final', 0)
 __version__ = get_version(VERSION)

--- a/src/wiki/models/article.py
+++ b/src/wiki/models/article.py
@@ -28,7 +28,7 @@ class Article(models.Model):
     current_revision = models.OneToOneField(
         'ArticleRevision', verbose_name=_('current revision'),
         blank=True, null=True, related_name='current_set',
-        on_delete=models.SET_NULL,
+        on_delete=models.CASCADE,
         help_text=_(
             'The revision being displayed for this article. If you need to do a roll-back, simply change the value of this field.'),)
 

--- a/src/wiki/models/pluginbase.py
+++ b/src/wiki/models/pluginbase.py
@@ -161,7 +161,7 @@ class RevisionPlugin(ArticlePlugin):
         verbose_name=_('current revision'),
         blank=True,
         null=True,
-        on_delete=models.SET_NULL,
+        on_delete=models.CASCADE,
         related_name='plugin_set',
         help_text=_(
             'The revision being displayed for this plugin. '

--- a/src/wiki/models/urlpath.py
+++ b/src/wiki/models/urlpath.py
@@ -71,7 +71,7 @@ class URLPath(MPTTModel):
         'self',
         null=True,
         blank=True,
-        on_delete=models.SET_NULL,
+        on_delete=models.CASCADE,
         related_name='children',
         help_text=_("Position of URL path in the tree.")
     )

--- a/src/wiki/plugins/attachments/models.py
+++ b/src/wiki/plugins/attachments/models.py
@@ -31,7 +31,7 @@ class Attachment(ReusablePlugin):
     current_revision = models.OneToOneField(
         'AttachmentRevision', verbose_name=_('current revision'),
         blank=True, null=True, related_name='current_set',
-        on_delete=models.SET_NULL,
+        on_delete=models.CASCADE,
         help_text=_(
             'The revision of this attachment currently in use (on all articles using the attachment)'),)
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
   six>=1.9
   mock>=2.0
   Markdown==2.6.7
-  django_nyt==1.0b1
+  django_nyt==1.0
   bleach==1.5.0
   django18: Django==1.8.2
   django19: Django==1.9

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,17 @@ LINT =
 
 [testenv]
 
+whitelist_externals=
+  sh
+
 passenv =
   INCLUDE_SELENIUM_TESTS
   SELENIUM_SHOW_BROWSER
 
 commands =
+  # Test that there are no migrations needed -- on Django 1.11, we can
+  # use --check and remove the '!' which likely doesn't work on Windows
+  sh -c '! testproject/manage.py makemigrations --dry-run --exit --noinput'
   {toxinidir}/runtests.py --basetemp={envtmpdir} --ds=tests.settings --cov=src/wiki --cov-config .coveragerc {posargs}
 
 usedevelop = true


### PR DESCRIPTION
Also detect these problems in future PRs

Fix for non-default `on_delete` values specified in https://github.com/django-wiki/django-wiki/pull/759

 * [x] Halt tox when model changes are not reflected in migrations
 * [x] Fix un-reflected model changes

Fixes #771 