### PR TITLE
Remove deprecations

### DIFF
--- a/testproject/testproject/settings/base.py
+++ b/testproject/testproject/settings/base.py
@@ -55,7 +55,7 @@ INSTALLED_APPS = [
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/testproject/testproject/settings/dev.py
+++ b/testproject/testproject/settings/dev.py
@@ -12,7 +12,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 try:
     import debug_toolbar  # @UnusedImport
-    MIDDLEWARE_CLASSES = list(MIDDLEWARE_CLASSES) + [
+    MIDDLEWARE = list(MIDDLEWARE) + [
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     ]
     INSTALLED_APPS = list(INSTALLED_APPS) + ['debug_toolbar']

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -10,7 +10,7 @@ from wiki.urls import get_pattern as get_wiki_pattern
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^robots.txt', lambda _: HttpResponse('User-agent: *\nDisallow: /')),
 ]
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'wiki.plugins.macros.apps.MacrosConfig',
     'wiki.plugins.globalhistory.apps.GlobalHistoryConfig',
 ]
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/tests/testdata/urls.py
+++ b/tests/testdata/urls.py
@@ -9,7 +9,7 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Exctract from https://github.com/django-wiki/django-wiki/pull/755
Use new MIDDLEWARE setting and urls include (django >= 1.11)