### PR TITLE
Use django.urls where appropriate

### DIFF
--- a/src/wiki/compat.py
+++ b/src/wiki/compat.py
@@ -1,0 +1,9 @@
+try:
+    from django.urls import include, re_path as url
+except ImportError:
+    from django.conf.urls import include, url
+
+
+__all__ = [
+    'include', 'url'
+]

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -4,7 +4,7 @@ from django.apps import apps
 from django.conf import settings as django_settings
 from django.contrib.messages import constants as messages
 from django.core.files.storage import default_storage
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
 #: Should urls be case sensitive?

--- a/src/wiki/decorators.py
+++ b/src/wiki/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (HttpResponseForbidden, HttpResponseNotFound,
                          HttpResponseRedirect)
 from django.shortcuts import get_object_or_404, redirect

--- a/src/wiki/editors/__init__.py
+++ b/src/wiki/editors/__init__.py
@@ -1,5 +1,5 @@
 from wiki.conf import settings
-from django.core.urlresolvers import get_callable
+from django.urls import get_callable
 
 _EditorClass = None
 _editor = None

--- a/src/wiki/forms.py
+++ b/src/wiki/forms.py
@@ -8,7 +8,7 @@ from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
 from django.core import validators
-from django.core.urlresolvers import Resolver404, resolve
+from django.urls import Resolver404, resolve
 from django.core.validators import RegexValidator
 from django.forms.utils import flatatt
 from django.forms.widgets import HiddenInput

--- a/src/wiki/models/__init__.py
+++ b/src/wiki/models/__init__.py
@@ -1,6 +1,9 @@
 from django.apps import apps
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
+from django.urls import base
+from django import urls
+from django import shortcuts
 
 # TODO: Don't use wildcards
 from .article import *  # noqa
@@ -60,9 +63,7 @@ if apps.is_installed('django_notify'):
         'django-wiki: You need to change from django_notify to django_nyt in INSTALLED_APPS and your urlconfig.')
 
 
-from django.core import urlresolvers  # noqa
-
-original_django_reverse = urlresolvers.reverse
+original_django_reverse = urls.reverse
 
 
 def reverse(*args, **kwargs):
@@ -93,21 +94,12 @@ def reverse(*args, **kwargs):
     return url
 
 
-# Now we redefine reverse method
 reverse_lazy = lazy(reverse, str)
-urlresolvers.reverse = reverse
-urlresolvers.reverse_lazy = reverse_lazy
+
 
 # Patch up other locations of the reverse function
-try:
-    from django.urls import base
-    from django import urls
-    from django import shortcuts
-    base.reverse = reverse
-    base.reverse_lazy = reverse_lazy
-    urls.reverse = reverse
-    urls.reverse_lazy = reverse_lazy
-    shortcuts.reverse = reverse
-    urls.reverse_lazy = reverse_lazy
-except ImportError:
-    pass
+base.reverse = reverse
+base.reverse_lazy = reverse_lazy
+urls.reverse = reverse
+urls.reverse_lazy = reverse_lazy
+shortcuts.reverse = reverse

--- a/src/wiki/models/article.py
+++ b/src/wiki/models/article.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.db.models.fields import GenericIPAddressField as IPAddressField
 from django.db.models.signals import post_save, pre_delete, pre_save

--- a/src/wiki/models/urlpath.py
+++ b/src/wiki/models/urlpath.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models, transaction
 from django.db.models.signals import post_save, pre_delete
 # Django 1.6 transaction API, required for 1.8+

--- a/src/wiki/plugins/attachments/markdown_extensions.py
+++ b/src/wiki/plugins/attachments/markdown_extensions.py
@@ -2,7 +2,7 @@ import re
 
 import markdown
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from wiki.core.permissions import can_read
 from wiki.plugins.attachments import models

--- a/src/wiki/plugins/attachments/urls.py
+++ b/src/wiki/plugins/attachments/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from wiki.compat import url
 from wiki.plugins.attachments import views
 
 urlpatterns = [

--- a/src/wiki/plugins/attachments/wiki_plugin.py
+++ b/src/wiki/plugins/attachments/wiki_plugin.py
@@ -1,5 +1,5 @@
-from django.conf.urls import include, url
 from django.utils.translation import gettext as _
+from wiki.compat import include, url
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin
 from wiki.plugins.attachments import models, settings, views

--- a/src/wiki/plugins/globalhistory/wiki_plugin.py
+++ b/src/wiki/plugins/globalhistory/wiki_plugin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from wiki.compat import url
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin
 

--- a/src/wiki/plugins/images/views.py
+++ b/src/wiki/plugins/images/views.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _

--- a/src/wiki/plugins/images/wiki_plugin.py
+++ b/src/wiki/plugins/images/wiki_plugin.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url
 from django.utils.translation import gettext as _
+from wiki.compat import url
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin
 from wiki.plugins.images import forms, models, settings, views

--- a/src/wiki/plugins/links/wiki_plugin.py
+++ b/src/wiki/plugins/links/wiki_plugin.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
 from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
+from wiki.compat import url
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin
 from wiki.plugins.links import settings, views

--- a/src/wiki/plugins/links/wiki_plugin.py
+++ b/src/wiki/plugins/links/wiki_plugin.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin

--- a/src/wiki/plugins/macros/mdx/wikilinks.py
+++ b/src/wiki/plugins/macros/mdx/wikilinks.py
@@ -5,7 +5,7 @@ Extend the shipped Markdown extension 'wikilinks'
 import re
 
 import markdown
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from markdown.extensions import wikilinks
 
 

--- a/src/wiki/plugins/notifications/models.py
+++ b/src/wiki/plugins/notifications/models.py
@@ -1,6 +1,6 @@
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import signals
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django_nyt.models import Subscription
 from django_nyt.utils import notify

--- a/src/wiki/plugins/notifications/wiki_plugin.py
+++ b/src/wiki/plugins/notifications/wiki_plugin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from wiki.compat import url
 from wiki.core.plugins import registry
 from wiki.core.plugins.base import BasePlugin
 

--- a/src/wiki/urls.py
+++ b/src/wiki/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from wiki.compat import include, url
 from wiki.conf import settings
 from wiki.core.plugins import registry
 from wiki.core.plugins.loader import load_wiki_plugins

--- a/src/wiki/views/accounts.py
+++ b/src/wiki/views/accounts.py
@@ -14,7 +14,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model, login as auth_login
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.forms import AuthenticationForm
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
 from django.views.generic.base import View

--- a/src/wiki/views/article.py
+++ b/src/wiki/views/article.py
@@ -3,7 +3,7 @@ import logging
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.db.models import Q
 from django.http import Http404

--- a/testproject/testproject/settings/base.py
+++ b/testproject/testproject/settings/base.py
@@ -10,7 +10,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 
 import os
 
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,10 +1,10 @@
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.http.response import HttpResponse
 from django.views.static import serve as static_serve
 from django_nyt.urls import get_pattern as get_notify_pattern
+from wiki.compat import include, url
 from wiki.urls import get_pattern as get_wiki_pattern
 
 admin.autodiscover()

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,7 +3,7 @@ import unittest
 
 import django_functest
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import Context, Template
 from django.test import TestCase, override_settings
 

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1,9 +1,9 @@
 from django.apps import apps
-from django.conf.urls import url
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.test.testcases import TestCase
 
+from wiki.compat import include, url
 from wiki.conf import settings
 from wiki.managers import ArticleManager
 from wiki.models import Article, ArticleRevision, URLPath

--- a/tests/core/test_urls.py
+++ b/tests/core/test_urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.test.testcases import TestCase
 from django_nyt.urls import get_pattern as get_notify_pattern
+from wiki.compat import include, url
 from wiki.models import Article, URLPath
 from wiki.urls import get_pattern as get_wiki_pattern
 from wiki.urls import WikiURLPatterns

--- a/tests/plugins/attachments/test_views.py
+++ b/tests/plugins/attachments/test_views.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from wiki.models import URLPath
 
 from ...base import RequireRootArticleMixin, ArticleWebTestUtils, DjangoClientTestBase

--- a/tests/plugins/globalhistory/test_globalhistory.py
+++ b/tests/plugins/globalhistory/test_globalhistory.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from wiki.models import URLPath
 
 from ...base import (ArticleWebTestUtils, DjangoClientTestBase,

--- a/tests/plugins/images/test_views.py
+++ b/tests/plugins/images/test_views.py
@@ -2,7 +2,7 @@ import base64
 from io import BytesIO
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from wiki.core.plugins import registry as plugin_registry
 from wiki.models import URLPath
 from wiki.plugins.images import models

--- a/tests/plugins/links/test_links.py
+++ b/tests/plugins/links/test_links.py
@@ -1,5 +1,5 @@
 import markdown
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.test import TestCase
 from wiki.models import URLPath
 from wiki.plugins.links.mdx.djangowikilinks import WikiPathExtension

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,6 @@
 import os
 
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 
 TESTS_DATA_ROOT = os.path.dirname(__file__)

--- a/tests/testdata/urls.py
+++ b/tests/testdata/urls.py
@@ -1,8 +1,8 @@
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django_nyt.urls import get_pattern as get_notify_pattern
+from wiki.compat import include, url
 from wiki.urls import get_pattern as get_wiki_pattern
 
 admin.autodiscover()


### PR DESCRIPTION
Exctract from https://github.com/django-wiki/django-wiki/pull/755
Use `django.urls` if possible (django >= 1.11 compatible)