### PR TITLE
Use the full path to the markdown extension with Python's dot notation.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,7 +23,8 @@ Added
 Changed
 ~~~~~~~
 
- * ...
+ * Use full path names for ``MARKDOWN_KWARGS['extensions']`` as short names
+   support wil be removed in ``Markdown 2.7`` :url-issue:`823`
 
 Fixed
 ~~~~~

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -35,15 +35,15 @@ MARKDOWN_SANITIZE_HTML = getattr(
 #:    WIKI_MARKDOWN_KWARGS = {'extension_configs': {'toc': _('Contents of this article')}}
 MARKDOWN_KWARGS = {
     'extensions': [
-        'footnotes',
-        'attr_list',
-        'smart_strong',
-        'footnotes',
-        'attr_list',
-        'def_list',
-        'tables',
-        'abbr',
-        'sane_lists',
+        'markdown.extensions.footnotes',
+        'markdown.extensions.attr_list',
+        'markdown.extensions.smart_strong',
+        'markdown.extensions.footnotes',
+        'markdown.extensions.attr_list',
+        'markdown.extensions.def_list',
+        'markdown.extensions.tables',
+        'markdown.extensions.abbr',
+        'markdown.extensions.sane_lists',
     ],
     'extension_configs': {
         'toc': {


### PR DESCRIPTION
Using short names for Markdown's builtin extensions is deprecated.