### PR TITLE
Use --check option to check for test project's migrations.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,7 @@ passenv =
   SELENIUM_SHOW_BROWSER
 
 commands =
-  # Test that there are no migrations needed -- on Django 1.11, we can
-  # use --check and remove the '!' which likely doesn't work on Windows
-  sh -c '! testproject/manage.py makemigrations --dry-run --exit --noinput'
+  sh -c 'testproject/manage.py makemigrations --check'
   pytest --basetemp={envtmpdir} --ds=tests.settings --cov={envsitepackagesdir}/wiki --cov-config .coveragerc {posargs}
 
 usedevelop = false


### PR DESCRIPTION
I'm not sure about keeping `! ` to accommodate Windows users.  