### PR TITLE
Add a default app config

### DIFF
--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -17,5 +17,8 @@
 
 from wiki.core.version import get_version
 
+
+default_app_config = 'wiki.apps.WikiConfig'
+
 VERSION = (0, 4, 0, 'alpha', 2)
 __version__ = get_version(VERSION)


### PR DESCRIPTION
Was it the intention to leave out this? Because it kind of forces people to specify application configs, although there is a setting (also in Django 2.0) for this: https://docs.djangoproject.com/en/2.0/ref/applications/#for-application-authors

CC: @rsalmaso @atombrella 