### PR TITLE
Added tests for the wikilinks plugin.

### DIFF
--- a/src/wiki/plugins/macros/mdx/wikilinks.py
+++ b/src/wiki/plugins/macros/mdx/wikilinks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Extend the shipped Markdown extension 'wikilinks'
 """

--- a/tests/plugins/macros/test_links.py
+++ b/tests/plugins/macros/test_links.py
@@ -1,0 +1,12 @@
+from tests.base import RequireRootArticleMixin, TestBase
+from wiki.core import markdown
+from wiki.plugins.macros.mdx.wikilinks import WikiLinkExtension
+
+
+class WikiLinksTests(RequireRootArticleMixin, TestBase):
+    def test_wikilink(self):
+        md = markdown.ArticleMarkdown(article=self.root_article, extensions=[WikiLinkExtension()])
+        md_text = md.convert('[[Root Article]]')
+        self.assertEqual(
+            md_text, '<p><a class="wiki_wikilink" href="/Root_Article/">Root Article</a></p>'
+        )


### PR DESCRIPTION
Please don't merge right away. I'm somewhat confused about the replication of the extension provided by `Markdown`, as it appears it's only due to the `md.article` bit.

There's also an option to configure the `html_class` which seems to be another reason for the duplication.

The shebangs are different places in the code-base, they shouldn't be needed. I removed it from the `wikilinks.py` file.