### PR TITLE
Change order of safe and linebreak in template

### DIFF
--- a/src/wiki/plugins/macros/templates/wiki/plugins/macros/sidebar.html
+++ b/src/wiki/plugins/macros/templates/wiki/plugins/macros/sidebar.html
@@ -3,7 +3,7 @@
 
 {% for macro in macros %}
 <h4>{{ macro.short_description }}</h4>
-{{ macro.help_text|linebreaks|safe }}
+{{ macro.help_text|safe|linebreaks }}
 {% if macro.example_code %}
 <pre>{{ macro.example_code }}</pre>
 {% endif %}


### PR DESCRIPTION
The safe filter was not applied because it was after the linebreak filter.