### PR TITLE
 Added some tests for the AttachmentRevision model.

### DIFF
--- a/src/wiki/plugins/attachments/models.py
+++ b/src/wiki/plugins/attachments/models.py
@@ -86,8 +86,7 @@ def upload_path(instance, filename):
 
     # Has to match original extension filename
     if instance.id and instance.attachment and instance.attachment.original_filename:
-        original_extension = instance.attachment.original_filename.split(
-            ".")[-1]
+        original_extension = instance.attachment.original_filename.split(".")[-1]
         if not extension.lower() == original_extension:
             raise IllegalFileExtension(
                 "File extension has to be '%s', not '%s'." %
@@ -173,11 +172,7 @@ def on_revision_delete(instance, *args, **kwargs):
     for depth in range(0, max_depth):
         delete_path = "/".join(path[:-depth] if depth > 0 else path)
         try:
-            if len(
-                os.listdir(
-                    os.path.join(
-                        django_settings.MEDIA_ROOT,
-                        delete_path))) == 0:
+            if len(os.listdir(os.path.join(django_settings.MEDIA_ROOT, delete_path))) == 0:
                 os.rmdir(delete_path)
         except OSError:
             # Raised by os.listdir if directory is missing

--- a/tests/plugins/attachments/test_models.py
+++ b/tests/plugins/attachments/test_models.py
@@ -1,0 +1,31 @@
+from tests.base import RequireRootArticleMixin, TestBase
+from wiki.plugins.attachments.models import AttachmentRevision, Attachment
+
+
+class AttachmentRevisionTests(RequireRootArticleMixin, TestBase):
+
+    def setUp(self):
+        super().setUp()
+        self.attachment = Attachment.objects.create(
+            article=self.root_article, original_filename='blah.txt',
+        )
+        self.revision = AttachmentRevision.objects.create(
+            attachment=self.attachment, file=None, description='muh',
+            revision_number=1,
+        )
+
+    def test_revision_no_file(self):
+        # Intentionally, there are no asserts, as the test just needs to
+        # target an if-branch in the pre-delete signal for AttachmentRevision
+        self.revision.delete()
+
+    def test_revision_file_size(self):
+        self.assertIsNone(self.revision.get_size())
+
+    def test_get_filename_no_file(self):
+        self.assertIsNone(self.revision.get_filename())
+
+    def test_str(self):
+        self.assertEqual(str(self.revision), "%s: %s (r%d)" % (
+            'Root Article', 'blah.txt', 1,
+        ))


### PR DESCRIPTION
`Field` has both `blank` and `null` set to `False`, so I believe this should be dead.