### PR TITLE
Mark editor sidebar headline as safe html

### DIFF
--- a/src/wiki/templates/wiki/includes/editor_sidebar.html
+++ b/src/wiki/templates/wiki/includes/editor_sidebar.html
@@ -20,7 +20,7 @@
 
     <div class="panel-heading">
       <a class="panel-toggle" href="#collapse_{{ plugin.slug }}" data-toggle="collapse">
-        <h3 class="panel-title"><span class="fa fa-fw {{ plugin.sidebar.icon_class }}"></span> {{ plugin.sidebar.headline }}</h3>
+        <h3 class="panel-title"><span class="fa fa-fw {{ plugin.sidebar.icon_class }}"></span> {{ plugin.sidebar.headline|safe }}</h3>
       </a>
     </div>
 


### PR DESCRIPTION
I'm not completely sure this is safe to do. But I don't se any place this is exposed to an end user.