### PR TITLE
Pin bleach >=2.1,<2.2

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -25,6 +25,7 @@ Added
 Changed
 ~~~~~~~
 
+ * Dependency for escaping HTML and safeguarding against injections ``bleach`` upgraded ``>=2.1,<2.2`` (last-partizan) :url-issue:`702`
  * Use full path names for ``MARKDOWN_KWARGS['extensions']`` as short names
    support wil be removed in ``Markdown 2.7`` :url-issue:`823`
  * Support for ``include('wiki.urls')`` for urls instantiation :url-issue:`827`

--- a/requirements_readthedocs.txt
+++ b/requirements_readthedocs.txt
@@ -8,4 +8,4 @@ django-mptt>=0.8.6,<0.9
 django-sekizai>=0.10
 sorl-thumbnail>=12,<13
 Markdown>=2.6,<2.7
-bleach>=2
+bleach>=2.1,<2.2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_path(fname):
 
 install_requirements = [
     "Django>=1.11,<2.1",
-    "bleach>=2",
+    "bleach>=2.1,<2.2",
     "Pillow",
     "django-nyt>=1.1b1,<1.2",
     "django-mptt>=0.9,<0.10",


### PR DESCRIPTION
@last-partizan just to make sure, and trusting in the semantic versioning of the bleach team, we should use the series that we know to work. Is that okay for your purpose?

Also added a release note. Can release immediate as another 0.4 version...