### PR TITLE
Update installation.rst: fix import

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -91,7 +91,7 @@ Configure ``context_processors``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``django-wiki`` uses the `Django Templates` backend.
-Add ``'sekizai.context_processors.sekizai'`` and ``'django.core.context_processors.debug'`` to
+Add ``'sekizai.context_processors.sekizai'`` and ``'django.template.context_processors.debug'`` to
 ``context_processors`` section of your template backend settings.
 Please refer to the `Django templates docs <https://docs.djangoproject.com/en/1.11/topics/templates/#django.template.backends.django.DjangoTemplates/>`_
 to see the current default setting for this variable.


### PR DESCRIPTION
`context_processors` in Django 1.10 and above has been moved from `core` to `template`.

(source: https://stackoverflow.com/a/44071228/196244 )