### PR TITLE
Convert UNIX line endings to DOS in add_revision()

### DIFF
--- a/src/wiki/models/article.py
+++ b/src/wiki/models/article.py
@@ -153,6 +153,7 @@ class Article(models.Model):
         new_revision.article = self
         new_revision.previous_revision = self.current_revision
         if save:
+            new_revision.clean()
             new_revision.save()
         self.current_revision = new_revision
         if save:
@@ -371,6 +372,12 @@ class ArticleRevision(BaseRevisionMixin, models.Model):
 
     def __str__(self):
         return "%s (%d)" % (self.title, self.revision_number)
+
+    def clean(self):
+        # Enforce DOS line endings \r\n. It is the standard for web browsers,
+        # but when revisions are created programatically, they might
+        # have UNIX line endings \n instead.
+        self.content = self.content.replace('\r', '').replace('\n', '\r\n')
 
     def inherit_predecessor(self, article):
         """

--- a/tests/core/test_basic.py
+++ b/tests/core/test_basic.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from wiki.conf import settings as wiki_settings
 from wiki.forms import Group
-from wiki.models import URLPath
+from wiki.models import Article, ArticleRevision, URLPath
 
 from ..base import wiki_override_settings
 from ..testdata.models import CustomGroup
@@ -26,3 +26,13 @@ class CustomGroupTests(TestCase):
     def test_custom(self):
         self.assertEqual(Group, CustomGroup)
         self.assertEqual(wiki_settings.GROUP_MODEL, 'testdata.CustomGroup')
+
+
+class LineEndingsTests(TestCase):
+
+    def test_manager(self):
+
+        article = Article()
+        article.add_revision(ArticleRevision(title="Root", content="Hello\nworld"),
+                             save=True)
+        self.assertEqual("Hello\r\nworld", article.current_revision.content)


### PR DESCRIPTION
When a wiki page is edited from a browser, any non-DOS line endings will
be converted to DOS line endings \r\n. This creates an unnecessarily
large diff on the first edit in case the initial revision was created
programatically and with UNIX line endings \n.