### PR TITLE
fix i18n issues

### DIFF
--- a/wiki/plugins/attachments/templates/wiki/plugins/attachments/delete.html
+++ b/wiki/plugins/attachments/templates/wiki/plugins/attachments/delete.html
@@ -9,7 +9,7 @@
 {% if attachment.article == article %}
 <h2>{% trans "Delete" %} "{{ attachment.current_revision.get_filename }}"?</h2>
   <p class="lead">
-    {% blocktrans with attachment.original_filename as filename %}
+    {% blocktrans with attachment.original_filename as filename trimmed %}
     The file may be referenced on other articles. Deleting it means that they will loose their references to this file. The following articles reference this file:
     {% endblocktrans %}
   </p>
@@ -39,7 +39,7 @@
 {% else %}
   <h2>{% trans "Remove" %} "{{ attachment.current_revision.get_filename }}"?</h2>
   <p class="lead">
-    {% blocktrans with attachment.original_filename as filename %}
+    {% blocktrans with attachment.original_filename as filename trimmed %}
     You can remove a reference to a file, but it will retain its references on other articles.
     {% endblocktrans %}
   </p>

--- a/wiki/plugins/attachments/templates/wiki/plugins/attachments/replace.html
+++ b/wiki/plugins/attachments/templates/wiki/plugins/attachments/replace.html
@@ -9,12 +9,12 @@
 <h2>{% trans "Replace" %} "{{ attachment.current_revision.get_filename }}"</h2>
 {% if attachment.articles.count > 1 %}
 <p class="lead">
-  {% blocktrans with attachment.original_filename as filename %}
+  {% blocktrans with attachment.original_filename as filename trimmed %}
   Replacing an attachment means adding a new file that will be used in its place. All references to the file will be replaced by the one you upload and the file will be downloaded as <strong>{{ filename }}</strong>. Please note that this attachment is in use on other articles, you may distort contents. However, do not hestitate to take advantage of this and make replacements for the listed articles where necessary. This way of working is more efficient....
   {% endblocktrans %}
 </p>
 <h3>
-  {% blocktrans with attachment.current_revision.get_filename as filename %}
+  {% blocktrans with attachment.current_revision.get_filename as filename trimmed %}
   Articles using {{ filename }}
   {% endblocktrans %}</h3>
 <ul>
@@ -23,7 +23,7 @@
 <hr />
 {% else %}
 <p class="lead">
-  {% blocktrans with attachment.original_filename as filename %}
+  {% blocktrans with attachment.original_filename as filename trimmed %}
   Replacing an attachment means adding a new file that will be used in its place. All references to the file will be replaced by the one you upload and the file will be downloaded as <strong>{{ filename }}</strong>.
   {% endblocktrans %}
 </p>

--- a/wiki/templates/wiki/dir.html
+++ b/wiki/templates/wiki/dir.html
@@ -37,7 +37,7 @@
 
 <p>
   {% with paginator.object_list.count as cnt %}
-    {% blocktrans with urlpath.path as path and cnt|pluralize:_("article,articles") as articles_plur and cnt|pluralize:_("is,are") as articles_plur_verb %}
+    {% blocktrans with urlpath.path as path and cnt|pluralize:_("article,articles") as articles_plur and cnt|pluralize:_("is,are") as articles_plur_verb trimmed %}
       Browsing <strong><a href="{{ self_url }}">/{{ path }}</a></strong>. There {{ articles_plur_verb }} <strong>{{ cnt }} {{ articles_plur }}</strong> in this level.
     {% endblocktrans %}
   {% endwith %}

--- a/wiki/templates/wiki/includes/anonymous_blocked.html
+++ b/wiki/templates/wiki/includes/anonymous_blocked.html
@@ -4,7 +4,7 @@
 {% url 'wiki:signup' as signup_url %}
 {% url 'wiki:login' as login_url %}
 {% if login_url and signup_url %}
-  {% blocktrans %}
+  {% blocktrans trimmed %}
   You need to <a href="{{ login_url }}">log in</a> or <a href="{{ signup_url }}">sign up</a> to use this function.
   {% endblocktrans %}
 {% else %}


### PR DESCRIPTION
Used trimmed to fix the i18n generate issues and remove unnecessary newline and endline characters created.
This fixes the following error which comes when updating translations for platform. 
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/bin/i18n_tool", line 11, in <module>
    sys.exit(main())
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/main.py", line 60, in main
    return module.main()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/__init__.py", line 51, in __call__
    return self.run(args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 176, in run
    merge_files(configuration, locale, fail_if_missing=args.strict)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 80, in merge_files
    merge(configuration, locale, target, sources, fail_if_missing)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 59, in merge
    duplicate_entries = clean_pofile(merged_filename)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 130, in clean_pofile
    ).encode('utf-8')
ValueError: 
  You need to <a href="%(login_url)s">log in</a> or <a href="%(signup_url)s">sign up</a> to use this function.
   starts or ends with a new line character, which is not allowed. Please fix before continuing. Source string is found in [(u'lms/templates/wiki/includes/anonymous_blocked.html', None), (u'wiki/templates/wiki/includes/anonymous_blocked.html', None)]
 
Updated all similar cases.