### PR TITLE
Re-enable lint check after Python 2.7 got rm'ed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ env:
 
 matrix:
   exclude:
-  - python: "3.4"
-    env: LINT="yes"
   - python: "3.5"
     env: LINT="yes"
   - python: "3.6"


### PR DESCRIPTION
@Mortal sorry about that, seems that when we removed Python 2.7, we also implicitly removed the last non-excluded `LINT=yes` from the Travis matrix :)