### PR TITLE
Add support for markdown >= 3.0

### DIFF
--- a/requirements_readthedocs.txt
+++ b/requirements_readthedocs.txt
@@ -5,5 +5,5 @@ Django>=1.8,<1.12
 Pillow
 django-sekizai>=0.10
 sorl-thumbnail>=12,<13
-Markdown>=2.6,<2.7
+Markdown>=3.0.0,<3.1.0
 bleach>=2.1,<2.2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requirements = [
     "django-mptt>=0.9,<0.10",
     "django-sekizai>=0.10",
     "sorl-thumbnail>=12,<13",
-    "Markdown>=2.6,<2.7",
+    "Markdown>=3.0.0,<3.1.0"
 ]
 
 test_requirements = [

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -51,7 +51,6 @@ MARKDOWN_KWARGS = {
     'extensions': [
         'markdown.extensions.footnotes',
         'markdown.extensions.attr_list',
-        'markdown.extensions.smart_strong',
         'markdown.extensions.footnotes',
         'markdown.extensions.attr_list',
         'markdown.extensions.def_list',

--- a/src/wiki/core/markdown/mdx/codehilite.py
+++ b/src/wiki/core/markdown/mdx/codehilite.py
@@ -58,7 +58,7 @@ class WikiFencedBlockPreprocessor(Preprocessor):
                 if m.group('lang'):
                     lang = m.group('lang')
                 html = highlight(m.group('code'), self.config, self.markdown.tab_length, lang=lang)
-                placeholder = self.markdown.htmlStash.store(html, safe=True)
+                placeholder = self.markdown.htmlStash.store(html)
                 text = '%s\n%s\n%s' % (text[:m.start()],
                                        placeholder,
                                        text[m.end():])
@@ -76,7 +76,7 @@ class HiliteTreeprocessor(Treeprocessor):
         for block in blocks:
             if len(block) == 1 and block[0].tag == 'code':
                 html = highlight(block[0].text, self.config, self.markdown.tab_length)
-                placeholder = self.markdown.htmlStash.store(html, safe=True)
+                placeholder = self.markdown.htmlStash.store(html)
                 # Clear codeblock in etree instance
                 block.clear()
                 # Change to p element which will later
@@ -92,7 +92,7 @@ class WikiCodeHiliteExtension(CodeHiliteExtension):
     because it's hard to extend...
     """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add HilitePostprocessor to Markdown instance. """
         hiliter = HiliteTreeprocessor(md)
         hiliter.config = self.getConfigs()

--- a/src/wiki/core/markdown/mdx/previewlinks.py
+++ b/src/wiki/core/markdown/mdx/previewlinks.py
@@ -6,7 +6,7 @@ class PreviewLinksExtension(markdown.Extension):
 
     """Markdown Extension that sets all anchor targets to _blank when in preview mode"""
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.treeprocessors.add('previewlinks', PreviewLinksTree(md), "_end")
 
 

--- a/src/wiki/core/markdown/mdx/responsivetable.py
+++ b/src/wiki/core/markdown/mdx/responsivetable.py
@@ -6,7 +6,7 @@ from markdown.util import etree
 class ResponsiveTableExtension(markdown.Extension):
     """Wraps all tables with Bootstrap's table-responsive class"""
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.treeprocessors.add('responsivetable', ResponsiveTableTree(md), "_end")
 
 

--- a/src/wiki/plugins/attachments/markdown_extensions.py
+++ b/src/wiki/plugins/attachments/markdown_extensions.py
@@ -16,7 +16,7 @@ class AttachmentExtension(markdown.Extension):
 
     """ Abbreviation Extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Insert AbbrPreprocessor before ReferencePreprocessor. """
         md.preprocessors.add(
             'dw-attachments',
@@ -80,7 +80,7 @@ class AttachmentPreprocessor(markdown.preprocessors.Preprocessor):
                         'attachment_can_read': attachment_can_read,
                     }
                 )
-                line = self.markdown.htmlStash.store(html, safe=True)
+                line = self.markdown.htmlStash.store(html)
             except models.Attachment.DoesNotExist:
                 html = (
                     """<span class="attachment attachment-deleted">Attachment with ID """
@@ -88,7 +88,7 @@ class AttachmentPreprocessor(markdown.preprocessors.Preprocessor):
                 ).format(attachment_id)
                 line = line.replace(
                     '[' + m.group(2) + ']',
-                    self.markdown.htmlStash.store(html, safe=True)
+                        self.markdown.htmlStash.store(html)
                 )
             new_text.append(before + line + after)
         return new_text

--- a/src/wiki/plugins/images/markdown_extensions.py
+++ b/src/wiki/plugins/images/markdown_extensions.py
@@ -23,7 +23,7 @@ class ImageExtension(markdown.Extension):
 
     """ Images plugin markdown extension for django-wiki. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.inlinePatterns.add('dw-images', ImagePattern(IMAGE_RE, md), '>link')
         md.postprocessors.add('dw-images-cleanup', ImagePostprocessor(md), '>raw_html')
 
@@ -76,8 +76,8 @@ class ImagePattern(markdown.inlinepatterns.Pattern):
             },
         )
         html_before, html_after = html.split(caption_placeholder)
-        placeholder_before = self.markdown.htmlStash.store(html_before, safe=True)
-        placeholder_after = self.markdown.htmlStash.store(html_after, safe=True)
+        placeholder_before = self.markdown.htmlStash.store(html_before)
+        placeholder_after = self.markdown.htmlStash.store(html_after)
         return placeholder_before + caption + placeholder_after + trailer
 
 

--- a/src/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/src/wiki/plugins/links/mdx/djangowikilinks.py
@@ -23,7 +23,7 @@ from markdown.util import etree
 from wiki import models
 
 
-class WikiPathExtension(markdown.Extension):
+class WikiPathExtension(markdown.extensions.Extension):
 
     def __init__(self, configs):
         # set extension defaults
@@ -42,12 +42,12 @@ class WikiPathExtension(markdown.Extension):
         for key, value in configs:
             self.setConfig(key, value)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         self.md = md
 
         # append to end of inline patterns
         WIKI_RE = r'\[(?P<label>[^\]]+?)\]\(wiki:(?P<wikipath>[a-zA-Z0-9\./_-]*?)(?P<fragment>#[a-zA-Z0-9\./_-]*)?\)'
-        wikiPathPattern = WikiPath(WIKI_RE, self.config, markdown_instance=md)
+        wikiPathPattern = WikiPath(WIKI_RE, self.config, md=md)
         wikiPathPattern.md = md
         md.inlinePatterns.add('djangowikipath', wikiPathPattern, "<reference")
 
@@ -131,5 +131,5 @@ class WikiPath(markdown.inlinepatterns.Pattern):
         return base_url, html_class
 
 
-def makeExtension(configs=None):
-    return WikiPathExtension(configs=configs)
+def makeExtension(**kwargs):
+    return WikiPathExtension(**kwargs)

--- a/src/wiki/plugins/links/mdx/urlize.py
+++ b/src/wiki/plugins/links/mdx/urlize.py
@@ -162,16 +162,16 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
         return el
 
 
-class UrlizeExtension(markdown.Extension):
-
+class UrlizeExtension(markdown.extensions.Extension):
     """ Urlize Extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def extendMarkdown(self, md):
         """ Replace autolink with UrlizePattern """
         md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
 
 
-def makeExtension(configs=None):
-    if configs is None:
-        configs = {}
-    return UrlizeExtension(configs=configs)
+def makeExtension(*args, **kwargs):
+    return UrlizeExtension(*args, **kwargs)

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -20,7 +20,7 @@ class MacroExtension(markdown.Extension):
 
     """ Macro plugin markdown extension for django-wiki. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.inlinePatterns.add('dw-macros', MacroPattern(MACRO_RE, md), '>link')
 
 
@@ -62,7 +62,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
                     article__current_revision__deleted=False),
                 'depth': int(depth) + 1,
             })
-        return self.markdown.htmlStash.store(html, safe=True)
+        return self.markdown.htmlStash.store(html)
     article_list.meta = dict(
         short_description=_('Article list'),
         help_text=_('Insert a list of articles in this level.'),

--- a/src/wiki/plugins/macros/mdx/toc.py
+++ b/src/wiki/plugins/macros/mdx/toc.py
@@ -28,9 +28,9 @@ class WikiTocExtension(TocExtension):
         kwargs.setdefault('slugify', wiki_slugify)
         super().__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         if 'toc' in settings.METHODS:
-            TocExtension.extendMarkdown(self, md, md_globals)
+            TocExtension.extendMarkdown(self, md)
 
 
 def makeExtension(*args, **kwargs):

--- a/src/wiki/plugins/macros/mdx/wikilinks.py
+++ b/src/wiki/plugins/macros/mdx/wikilinks.py
@@ -34,7 +34,7 @@ class WikiLinkExtension(Extension):
         }
         super().__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         self.md = md
 
         # append to end of inline patterns
@@ -44,22 +44,18 @@ class WikiLinkExtension(Extension):
         md.inlinePatterns.add('wikilink', wikilinkPattern, "<not_strong")
 
 
-class WikiLinks(wikilinks.WikiLinks):
+class WikiLinks(wikilinks.WikiLinksInlineProcessor):
 
-    def handleMatch(self, m):
-        if m.group(2).strip():
-            base_url, end_url, html_class = self._getMeta()
-            label = m.group(2).strip()
-            url = self.config['build_url'](label, base_url, end_url, self.md)
-            a = markdown.util.etree.Element('a')
-            a.text = label
-            a.set('href', url)
-            if html_class:
-                a.set('class', html_class)
-        else:
-            a = ''
-        return a
-
+    def handleMatch(self, m, data):
+        base_url, end_url, html_class = self._getMeta()
+        label = m.group(1).strip()
+        url = self.config['build_url'](label, base_url, end_url, self.md)
+        a = markdown.util.etree.Element('a')
+        a.text = label
+        a.set('href', url)
+        if html_class:
+            a.set('class', html_class)
+        return a, m.start(0), m.end(0)
 
 def makeExtension(*args, **kwargs):
     """Return an instance of the extension."""

--- a/src/wiki/plugins/redlinks/mdx/redlinks.py
+++ b/src/wiki/plugins/redlinks/mdx/redlinks.py
@@ -102,7 +102,7 @@ class LinkExtension(Extension):
         }
         super().__init__(*args, **kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.registerExtension(self)
         self.md = md
         ext = self.TreeProcessorClass(md, self.getConfigs())

--- a/tests/plugins/links/test_urlize.py
+++ b/tests/plugins/links/test_urlize.py
@@ -252,11 +252,3 @@ def test_makeExtension_return_value():
     extension = makeExtension()
 
     assert isinstance(extension, UrlizeExtension)
-
-
-@mock.patch('wiki.plugins.links.mdx.urlize.UrlizeExtension')
-def test_makeExtension_initialises_using_passed_in_configuration(mock_UrlizeExtension):
-    my_config = mock.Mock()
-    makeExtension(my_config)
-
-    mock_UrlizeExtension.assert_called_once_with(configs=my_config)


### PR DESCRIPTION
[python-markdown](https://github.com/Python-Markdown/markdown) is now
at version 3.0.1. Some interfaces that were formerly deprecated
are now removed. Make corresponding changes here, notably:

- remove 'smart_strong'
- remove 'safe_mode' HTML (was not implemented)
- remove 'md_globals'
- fix positional argumenst (e.g. extensions=[])
- support InlineProcessor (instead of Pattern) in WikiLinks