### PR TITLE
Bump to 0.5.dev

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,15 @@ Release plan
 * **0.5** should remove Django 1.11 support and target Bootstrap v4, if you are interested in this work, please get in touch on Github!
 
 
+0.5.dev (unreleased)
+--------------------
+
+Changed
+~~~~~~~
+
+* Update to Markdown >= 3 :url-issue:`920` (Don Bowman)
+
+
 0.4.1
 -----
 

--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -19,5 +19,5 @@ from wiki.core.version import get_version
 
 default_app_config = 'wiki.apps.WikiConfig'
 
-VERSION = (0, 4, 1, 'final', 0)
+VERSION = (0, 5, 0, 'alpha', 0)
 __version__ = get_version(VERSION)


### PR DESCRIPTION
0.4 series is maintained in `releases/0.4.x` now