### PR TITLE
Fix the numbers are detected as TLD domains

### DIFF
--- a/src/wiki/plugins/links/mdx/urlize.py
+++ b/src/wiki/plugins/links/mdx/urlize.py
@@ -78,8 +78,8 @@ URLIZE_RE = (
     r'([A-F0-9]{1,4}:){1,6}:([A-F0-9]{1,4}){1,6}|'  # IPv6, zeros in middle removed.
     r'\[?([A-F0-9]{1,4}:){1,6}:\]?|'  # IPv6, trailing zeros removed
     r'\[?::\]?|'  # IPv6, just "empty" address
-    r'([A-Z0-9]([A-Z0-9-]{0,61}[A-Z0-9])?\.)+([A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # FQDN
-    r'localhost'  # localhost
+    r'([A-Z0-9]([A-Z0-9-]{0,61}[A-Z0-9])?\.)+([A-Z]{2,6}\.?|[A-Z]{2,}\.?)|'  # FQDN
+    #r'localhost'  # localhost
     r')'  # end host identifier group
 
     # Optional port

--- a/src/wiki/plugins/links/mdx/urlize.py
+++ b/src/wiki/plugins/links/mdx/urlize.py
@@ -78,8 +78,7 @@ URLIZE_RE = (
     r'([A-F0-9]{1,4}:){1,6}:([A-F0-9]{1,4}){1,6}|'  # IPv6, zeros in middle removed.
     r'\[?([A-F0-9]{1,4}:){1,6}:\]?|'  # IPv6, trailing zeros removed
     r'\[?::\]?|'  # IPv6, just "empty" address
-    r'([A-Z0-9]([A-Z0-9-]{0,61}[A-Z0-9])?\.)+([A-Z]{2,6}\.?|[A-Z]{2,}\.?)|'  # FQDN
-    #r'localhost'  # localhost
+    r'([A-Z0-9]([A-Z0-9-]{0,61}[A-Z0-9])?\.)+([A-Z]{2,6}\.?|[A-Z]{2,}\.?)'  # FQD
     r')'  # end host identifier group
 
     # Optional port


### PR DESCRIPTION
1. The error causes the numbers to be detected as a domain (TLD)
2.  I have seen that links are created by typing the word "localhost" This is a very frequent word, and in most occasions a redirect is not necessary.

#927 