### PR TITLE
Use User.get_username() for article cache instead of User.__str__

### DIFF
--- a/src/wiki/models/article.py
+++ b/src/wiki/models/article.py
@@ -207,9 +207,9 @@ class Article(models.Model):
 
     def get_cache_content_key(self, user=None):
         """Returns per-article-user cache key."""
-        return "{key}:{user!s}".format(
+        return "{key}:{user}".format(
             key=self.get_cache_key(),
-            user=user if user else "")
+            user=user.get_username() if user else "")
 
     def get_cached_content(self, user=None):
         """Returns cached version of rendered article.


### PR DESCRIPTION
Detailed description in #930 

Base the caching key on the username of a User instead of the `__str__`, to increase compatibility with Django projects using Memcached as their caching service.

The default behavior of `__str__` is to use `get_username()`, but many projects choose to overwrite the method for their custom users to show the users full name. 