### PR TITLE
Fix the numbers are detected as TLD domains 

### DIFF
--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -102,7 +102,8 @@ for tag in MARKDOWN_HTML_WHITELIST:
     if tag not in _default_attribute_whitelist:
         _default_attribute_whitelist[tag] = []
     _default_attribute_whitelist[tag].append('class')
-    _default_attribute_whitelist[tag].append('id')
+    _default_attribute_whitelist[tag].append('target')
+    _default_attribute_whitelist[tag].append('rel')
 
 _default_attribute_whitelist['img'].append('src')
 _default_attribute_whitelist['img'].append('alt')

--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -102,6 +102,7 @@ for tag in MARKDOWN_HTML_WHITELIST:
     if tag not in _default_attribute_whitelist:
         _default_attribute_whitelist[tag] = []
     _default_attribute_whitelist[tag].append('class')
+    _default_attribute_whitelist[tag].append('id')
     _default_attribute_whitelist[tag].append('target')
     _default_attribute_whitelist[tag].append('rel')
 

--- a/src/wiki/plugins/links/mdx/urlize.py
+++ b/src/wiki/plugins/links/mdx/urlize.py
@@ -78,8 +78,7 @@ URLIZE_RE = (
     r'([A-F0-9]{1,4}:){1,6}:([A-F0-9]{1,4}){1,6}|'  # IPv6, zeros in middle removed.
     r'\[?([A-F0-9]{1,4}:){1,6}:\]?|'  # IPv6, trailing zeros removed
     r'\[?::\]?|'  # IPv6, just "empty" address
-    r'([A-Z0-9]([A-Z0-9-]{0,61}[A-Z0-9])?\.)+([A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # FQDN
-    r'localhost'  # localhost
+    r'([A-Z0-9]([A-Z0-9-]{0,61}[A-Z0-9])?\.)+([A-Z]{2,6}\.?|[A-Z]{2,}\.?)'  # FQDN
     r')'  # end host identifier group
 
     # Optional port
@@ -156,6 +155,7 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
         el = markdown.util.etree.Element("a")
         el.set('href', url)
         el.set('target', '_blank')
+        el.set('rel', 'nofollow')     
         el.append(icon)
         el.append(span_text)
 

--- a/tests/plugins/links/test_urlize.py
+++ b/tests/plugins/links/test_urlize.py
@@ -7,7 +7,7 @@ from wiki.plugins.links.mdx.urlize import UrlizeExtension, makeExtension
 
 # Template accepts two strings - href value and link text value.
 EXPECTED_LINK_TEMPLATE = (
-    '<a href="%s" target="_blank">'
+    '<a href="%s" rel="nofollow" target="_blank">'
     '<span class="fa fa-external-link">'
     '</span>'
     '<span>'
@@ -104,14 +104,11 @@ FIXTURE_POSITIVE_MATCHES = [
     ),
     (
         'localhost',
-        EXPECTED_PARAGRAPH_TEMPLATE % ('http://localhost', 'localhost')
+        '<p>localhosts</p>',
     ),
 
     # Test port section.
-    (
-        'localhost:8000',
-        EXPECTED_PARAGRAPH_TEMPLATE % ('http://localhost:8000', 'localhost:8000')
-    ),
+
     (
         '10.1.1.1:8000',
         EXPECTED_PARAGRAPH_TEMPLATE % ('http://10.1.1.1:8000', '10.1.1.1:8000')
@@ -165,7 +162,7 @@ FIXTURE_NEGATIVE_MATCHES = [
     # localhost as part of another word.
     (
         'localhosts',
-        '<p>localhosts</p>'
+        EXPECTED_PARAGRAPH_TEMPLATE % ('http://localhost', 'localhost') 
     ),
 
     # Invalid FQDNs.

--- a/tests/plugins/links/test_urlize.py
+++ b/tests/plugins/links/test_urlize.py
@@ -102,10 +102,6 @@ FIXTURE_POSITIVE_MATCHES = [
         'my.long.domain.example.com',
         EXPECTED_PARAGRAPH_TEMPLATE % ('http://my.long.domain.example.com', 'my.long.domain.example.com')
     ),
-    (
-        'localhost',
-        '<p>localhosts</p>',
-    ),
 
     # Test port section.
 
@@ -157,12 +153,6 @@ FIXTURE_NEGATIVE_MATCHES = [
     (
         '.example .com',
         '<p>.example .com</p>'
-    ),
-
-    # localhost as part of another word.
-    (
-        'localhosts',
-        EXPECTED_PARAGRAPH_TEMPLATE % ('http://localhost', 'localhost') 
     ),
 
     # Invalid FQDNs.

--- a/tests/plugins/links/test_urlize.py
+++ b/tests/plugins/links/test_urlize.py
@@ -145,6 +145,21 @@ FIXTURE_POSITIVE_MATCHES = [
 
 
 FIXTURE_NEGATIVE_MATCHES = [
+    # localhost as part of another word.
+    (
+        'localhosts',
+        '<p>localhosts</p>'
+    ),
+    (
+        'localhost', 
+        '<p>localhost</p>'
+
+    ),
+    (
+        'localhost:8000', 
+        '<p>localhost:8000</p>'
+    ),
+   
     # Incomplete FQDNs.
     (
         'example.',
@@ -154,7 +169,6 @@ FIXTURE_NEGATIVE_MATCHES = [
         '.example .com',
         '<p>.example .com</p>'
     ),
-
     # Invalid FQDNs.
     (
         'example-.com',


### PR DESCRIPTION
All right, I'll try to correct the problems.
For now these are the ones that I have been able to notice
#927 

- [x]  error that creates links after a point

- [x] I have seen that links are created by typing the word "localhost" This is a very frequent word, and in most occasions a redirect is not necessary.

- [x] add rel nofollow to external links

- [x] handleMatch  "it's not working ' target ' , ' _blank '" 

Everything works. I've tried it in the latest version of Django-wiki in its master branch. I previously used a different version of django-wiki, many things changed from mardown 3.

Note: I have not tested correctly