### PR TITLE
update docs/installation.rst for django 2.2+

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -143,12 +143,12 @@ handling entirely, set ``WIKI_ACCOUNT_HANDLING = False``.
     WIKI_ACCOUNT_SIGNUP_ALLOWED = True
 
 After a user is logged in, they will be redirected to the value of
-``LOGIN_REDIRECT_URL``, which you can configure in your project settings to
+``LOGIN_REDIRECT_URL``, which you can configure in your project's settings.py to
 point to the root article:
 
 .. code-block:: python
 
-    from django.core.urlresolvers import reverse_lazy
+    from django.urls import reverse_lazy
     LOGIN_REDIRECT_URL = reverse_lazy('wiki:get', kwargs={'path': ''})
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -77,15 +77,6 @@ maintain the order due to database relational constraints:
     'wiki.plugins.macros.apps.MacrosConfig',
 
 
-Database
-~~~~~~~~
-
-To sync and create tables, do:
-
-::
-
-    python manage.py migrate
-
 Configure ``context_processors``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -117,6 +108,16 @@ to see the current default setting for this variable.
             },
         },
     ]
+
+Database
+~~~~~~~~
+
+To sync and create tables, do:
+
+::
+
+    python manage.py migrate
+
 
 
 Set ``SITE_ID``


### PR DESCRIPTION
### Issue Fixed for installation documentation
*  Issue of [ #1036 Change something in "installation.rst"](https://github.com/django-wiki/django-wiki/issues/1036#issue-590903102) is fixed
* Resolved two errors of the following:
```shell
SystemCheckError: System check identified some issues:
ERRORS:
?: (wiki.E009) needs sekizai.context_processors.sekizai in TEMPLATE['OPTIONS']['context_processors']
```


```shell
from django.core.urlresolvers import reverse_lazy
ImportError: No module named 'django.core.urlresolvers'
```