### PR TITLE
Soften a check failure 

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,15 @@ Release plan
 * **0.7.x** Milestone TBA
 
 
+0.6.1.dev
+---------
+
+Fixed
+~~~~~
+
+* Do not fail prematurely during Django checks framework (rare issue) :url-issue:`1059` (Benjamin Bach)
+
+
 0.6
 ---
 

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -38,7 +38,7 @@ class CheckTests(TestCase):
                 errors = registry.run_checks(tags=[Tags.context_processors])
                 expected_errors = [
                     Error(
-                        "needs %s in TEMPLATE['OPTIONS']['context_processors']"
+                        "needs %s in TEMPLATES[*]['OPTIONS']['context_processors']"
                         % context_processor[0],
                         id="wiki.%s" % context_processor[1],
                     )


### PR DESCRIPTION
Soften a check failure to not raise exceptions from template tag libraries too early.

This issue is quite rare, it's a copy of how django.contrib.admin has implemented this.