### PR TITLE
Editsection removed method .getchildren(), fix bytes-like object

### DIFF
--- a/src/wiki/core/markdown/mdx/responsivetable.py
+++ b/src/wiki/core/markdown/mdx/responsivetable.py
@@ -34,10 +34,10 @@ class ResponsiveTableTree(Treeprocessor):
 
     def move_children(self, element1, element2):
         """Moves children from element1 to element2"""
-        for child in element1.getchildren():
+        for child in list(element1):
             element2.append(child)
         # reversed is needed to safely remove items while iterating
-        for child in reversed(element1.getchildren()):
+        for child in reversed(list(element1)):
             element1.remove(child)
 
     def convert_to_wrapper(self, element):

--- a/src/wiki/plugins/editsection/markdown_extensions.py
+++ b/src/wiki/plugins/editsection/markdown_extensions.py
@@ -25,7 +25,7 @@ class EditSectionExtension(Extension):
 
 
 def get_header_id(header):
-    header_id = "".join(w[0] for w in re.findall(r"\w+", header))
+    header_id = "".join(w[0] for w in re.findall(r"\w+", str(header)))
     if not len(header_id):
         return "_"
     return header_id
@@ -39,7 +39,7 @@ class EditSectionProcessor(Treeprocessor):
         sec_level = -1
         sec_start = -1
 
-        for child in node.getchildren():
+        for child in list(node):
             match = self.HEADER_RE.match(child.tag.lower())
             if not match:
                 continue
@@ -86,7 +86,7 @@ class EditSectionProcessor(Treeprocessor):
         cur_pos = [0] * self.level
         last_level = 0
 
-        for child in node.getchildren():
+        for child in list(node):
             match = self.HEADER_RE.match(child.tag.lower())
             if not match:
                 continue

--- a/tests/plugins/editsection/test_editsection.py
+++ b/tests/plugins/editsection/test_editsection.py
@@ -74,6 +74,15 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
         )
         self.assertRegex(response.rendered_content, expected)
 
+    def test_broken_content(self):
+        # Regression test for https://github.com/django-wiki/django-wiki/issues/1094
+        TEST_CONTENT = "### [Here we go](#anchor)"
+        urlpath = URLPath.create_urlpath(
+            URLPath.root(), "testedit", title="TestEdit", content=TEST_CONTENT
+        )
+        output = urlpath.article.render()
+        print(output)
+
 
 class EditSectionEditBase(RequireRootArticleMixin, FuncBaseMixin):
     pass


### PR DESCRIPTION
2 problems are solved


- [x] Expected string or bytes-like object. 
#1094 
(r"\w+", header)) > (r"\w+", str(header)))


- [x]  Use iter(x) or list(x) instead of x.getchildren() 
#1091
https://docs.python.org/3.9/whatsnew/3.9.html#removed