### PR TITLE
Security fix (XSS) - Build HTML elements for notifications safely

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,15 @@ Release plan
 * **0.7.x** Removes Django 2.1 support, adds Django 3.1, 3.2
 
 
+0.7.9
+-----
+
+Security fixes
+~~~~~~~~~~~~~~
+
+* XSS vulnerability: Unescaped HTML in title propagated to notification (WhiteSource Vulnerability Research Team)
+
+
 0.7.8
 -----
 

--- a/src/wiki/__init__.py
+++ b/src/wiki/__init__.py
@@ -17,5 +17,5 @@ from wiki.core.version import get_version
 
 default_app_config = "wiki.apps.WikiConfig"
 
-VERSION = (0, 7, 8, "final", 0)
+VERSION = (0, 7, 9, "final", 0)
 __version__ = get_version(VERSION)

--- a/src/wiki/plugins/notifications/static/wiki/plugins/notifications/js/ui.js
+++ b/src/wiki/plugins/notifications/static/wiki/plugins/notifications/js/ui.js
@@ -19,11 +19,19 @@ function notify_update() {
         n = data.objects[i];
         notify_latest_id = n.pk>notify_latest_id ? n.pk:notify_latest_id;
         notify_oldest_id = (n.pk<notify_oldest_id || notify_oldest_id==0) ? n.pk:notify_oldest_id;
+        var element_outer_div = $("<div />");
+        var element_a = $("<a />", {href: URL_NOTIFY_GOTO + n.pk + "/"});
+        var element_message_div;
+        var element_since_div;
         if (n.occurrences > 1) {
-          element = $('<div><a href="'+URL_NOTIFY_GOTO+n.pk+'/"><div>'+n.message+'</div><div class="since">'+n.occurrences_msg+' - ' + n.since + '</div></a></div>')
+          element_message_div = $("<div />", {text: n.message});
+          element_since_div = $("<div />", {text: n.occurrences_msg+' - ' + n.since, class: "since"});
         } else {
-          element = $('<div><a href="'+URL_NOTIFY_GOTO+n.pk+'/"><div>'+n.message+'</div><div class="since">'+n.since+'</div></a></div>');
+          element_message_div = $("<div />", {text: n.message});
+          element_since_div = $("<div />", {text: n.since, class: "since"});
         }
+        element_a.append(element_message_div).append(element_since_div);
+        element = element_outer_div.append(element_a);
         element.addClass('dropdown-item notification-item');
         element.insertAfter('.notification-before-list');
       }


### PR DESCRIPTION
This fixes an exploitation scenario of which an attacker through a very short domain name may inject a `<script>` tag into a notification message through an article's title field.

This is mitigated by the fact that the messages are truncated at 25 chars and that most servers are hopefully running CSP.