### PR TITLE
update forms.py, fix unzip file function

### DIFF
--- a/src/wiki/plugins/attachments/forms.py
+++ b/src/wiki/plugins/attachments/forms.py
@@ -121,8 +121,11 @@ class AttachmentArchiveForm(AttachmentForm):
         if self.cleaned_data["unzip_archive"]:
             new_attachments = []
             try:
+                uploaded_file = self.cleaned_data.get("file", None) # could not use unzip function without it 
+                self.zipfile = zipfile.ZipFile(uploaded_file.file, mode="r") #could not use unzip function without it 
+
                 for zipinfo in self.zipfile.filelist:
-                    f = tempfile.NamedTemporaryFile(mode="r+w")
+                    f = tempfile.NamedTemporaryFile(mode="w+b") # it was r+w before, which was an incorrect mode
                     f.write(self.zipfile.read(zipinfo.filename))
                     f = File(f, name=zipinfo.filename)
                     try:


### PR DESCRIPTION
fix 'unzip file' (checkbox,  Create individual attachments for files in a .zip file - directories do not work.)  function in the attachment upload form. Without this fix, the function would throw out exceptions "'AttachmentArchiveForm' object has no attribute 'zipfile'" and a file mode error.   To test this fix, user would also need to enable .zip extension in settings.py of the django wiki project, such as the following:   WIKI_ATTACHMENTS_EXTENSIONS = ['pdf', 'doc', 'odt', 'docx', 'txt','zip']

![image](https://user-images.githubusercontent.com/25790388/147529609-d77f0b49-ed7d-4e24-97cb-5ab970a624d9.png)
