### PR TITLE
update forms.py to fix attachment form's "unzip file"  error

### DIFF
--- a/src/wiki/plugins/attachments/forms.py
+++ b/src/wiki/plugins/attachments/forms.py
@@ -121,8 +121,10 @@ class AttachmentArchiveForm(AttachmentForm):
         if self.cleaned_data["unzip_archive"]:
             new_attachments = []
             try:
+                uploaded_file = self.cleaned_data.get("file", None)  # added, was missing
+                self.zipfile = zipfile.ZipFile(uploaded_file.file, mode="r")  # added, was missing
                 for zipinfo in self.zipfile.filelist:
-                    f = tempfile.NamedTemporaryFile(mode="r+w")
+                    f = tempfile.NamedTemporaryFile(mode="w+b")  # fixed, the previous mode 'r+w' was incorrect
                     f.write(self.zipfile.read(zipinfo.filename))
                     f = File(f, name=zipinfo.filename)
                     try:


### PR DESCRIPTION
fix 'unzip file' (checkbox, Create individual attachments for files in a .zip file - directories do not work.) function in the attachment upload form. Without this fix, the function would throw out exceptions "'AttachmentArchiveForm' object has no attribute 'zipfile'" and a file mode error. To test this fix, user would also need to enable .zip extension in settings.py of the django wiki project, such as the following: WIKI_ATTACHMENTS_EXTENSIONS = ['pdf', 'doc', 'odt', 'docx', 'txt','zip']

![image](https://user-images.githubusercontent.com/25790388/147533834-a843972f-d1bd-40dd-a9f3-ec40b5848f6c.png)

Exception 1 note:

Environment:

Request Method: POST
Request URL: http://127.0.0.1:5555/grammar-research/_plugin/attachments/

Django Version: 3.2.6
Python Version: 3.8.10
Installed Applications:
['django.contrib.admin',
'django.contrib.auth',
'django.contrib.contenttypes',
'django.contrib.sessions',
'django.contrib.messages',
'django.contrib.staticfiles',
'django.contrib.sites.apps.SitesConfig',
'django.contrib.humanize.apps.HumanizeConfig',
'django_nyt.apps.DjangoNytConfig',
'mptt',
'sekizai',
'sorl.thumbnail',
'wiki.apps.WikiConfig',
'wiki.plugins.attachments.apps.AttachmentsConfig',
'wiki.plugins.notifications.apps.NotificationsConfig',
'wiki.plugins.images.apps.ImagesConfig',
'wiki.plugins.macros.apps.MacrosConfig']
Installed Middleware:
['django.middleware.security.SecurityMiddleware',
'django.contrib.sessions.middleware.SessionMiddleware',
'django.middleware.common.CommonMiddleware',
'django.middleware.csrf.CsrfViewMiddleware',
'django.contrib.auth.middleware.AuthenticationMiddleware',
'django.contrib.messages.middleware.MessageMiddleware',
'django.middleware.clickjacking.XFrameOptionsMiddleware']

Traceback (most recent call last):
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
response = get_response(request)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
return self.dispatch(request, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/utils/decorators.py", line 43, in _wrapper
return bound_method(*args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/decorators.py", line 171, in wrapper
return func(request, article, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/plugins/attachments/views.py", line 48, in dispatch
return super().dispatch(request, article, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/views/mixins.py", line 34, in dispatch
return super().dispatch(request, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/views/generic/base.py", line 98, in dispatch
return handler(request, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/views/generic/edit.py", line 142, in post
return self.form_valid(form)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/plugins/attachments/views.py", line 60, in form_valid
attachment_revision = form.save()
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/plugins/attachments/forms.py", line 130, in save
for zipinfo in self.zipfile.filelist:

Exception Type: AttributeError at /grammar-research/_plugin/attachments/
Exception Value: 'AttachmentArchiveForm' object has no attribute 'zipfile'

Exception 2 note: (appeared when the first exception was fixed)
Environment:

Request Method: POST
Request URL: http://127.0.0.1:5555/grammar-research/_plugin/attachments/

Django Version: 3.2.6
Python Version: 3.8.10
Installed Applications:
['django.contrib.admin',
'django.contrib.auth',
'django.contrib.contenttypes',
'django.contrib.sessions',
'django.contrib.messages',
'django.contrib.staticfiles',
'django.contrib.sites.apps.SitesConfig',
'django.contrib.humanize.apps.HumanizeConfig',
'django_nyt.apps.DjangoNytConfig',
'mptt',
'sekizai',
'sorl.thumbnail',
'wiki.apps.WikiConfig',
'wiki.plugins.attachments.apps.AttachmentsConfig',
'wiki.plugins.notifications.apps.NotificationsConfig',
'wiki.plugins.images.apps.ImagesConfig',
'wiki.plugins.macros.apps.MacrosConfig']
Installed Middleware:
['django.middleware.security.SecurityMiddleware',
'django.contrib.sessions.middleware.SessionMiddleware',
'django.middleware.common.CommonMiddleware',
'django.middleware.csrf.CsrfViewMiddleware',
'django.contrib.auth.middleware.AuthenticationMiddleware',
'django.contrib.messages.middleware.MessageMiddleware',
'django.middleware.clickjacking.XFrameOptionsMiddleware']

Traceback (most recent call last):
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
response = get_response(request)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
return self.dispatch(request, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/utils/decorators.py", line 43, in _wrapper
return bound_method(*args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/decorators.py", line 171, in wrapper
return func(request, article, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/plugins/attachments/views.py", line 48, in dispatch
return super().dispatch(request, article, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/views/mixins.py", line 34, in dispatch
return super().dispatch(request, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/views/generic/base.py", line 98, in dispatch
return handler(request, *args, **kwargs)
File "/home/ubuntu/.local/lib/python3.8/site-packages/django/views/generic/edit.py", line 142, in post
return self.form_valid(form)
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/plugins/attachments/views.py", line 60, in form_valid
attachment_revision = form.save()
File "/home/ubuntu/.local/lib/python3.8/site-packages/wiki/plugins/attachments/forms.py", line 131, in save
f = tempfile.NamedTemporaryFile(mode="r+w") #fix,was r+w before
File "/usr/lib/python3.8/tempfile.py", line 681, in NamedTemporaryFile
file = _io.open(fd, mode, buffering=buffering,

Exception Type: ValueError at /grammar-research/_plugin/attachments/
Exception Value: must have exactly one of create/read/write/append mode