### PR TITLE
Attachment search: Use exception-proof get_size when files deleted

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,15 @@ Release plan
 - **0.7.x** Removes Django 2.1 support, adds Django 3.1, 3.2
 
 
+0.7.11 (unreleased)
+-------------------
+
+Fixed
+~~~~~
+
+- Attachment search failing if files exceptionally missing on server :url-issue:`1162` (Benjamin Balder Bach)
+
+
 0.7.10
 ------
 

--- a/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/search.html
+++ b/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/search.html
@@ -46,7 +46,7 @@
     <td>
       {% include "wiki/includes/revision_info.html" with revision=attachment.current_revision hidedate=1 hidenumber=1 %}
     </td>
-    <td>{{ attachment.current_revision.file.size|filesizeformat }}</td>
+    <td>{{ attachment.current_revision.get_size|filesizeformat }}</td>
     <td style="text-align: right">
       <form method="POST" action="{% url 'wiki:attachments_add' path=urlpath.path article_id=article.id attachment_id=attachment.id %}">
         {% csrf_token %}


### PR DESCRIPTION
Fixes #1162