### PR TITLE
Update pytest due to TypeError: required field "lineno" missing from alias

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requirements = [
 
 test_requirements = [
     "django-functest>=1.0.3,<1.1",
-    "pytest>=5.3,<5.4",
+    "pytest>=6.2.5,<6.3",
     "pytest-django",
     "pytest-cov",
     "coverage",


### PR DESCRIPTION
Error described here: https://stackoverflow.com/questions/69528842/an-error-while-trying-to-execute-tests-on-python-3-10-with-pytest