### PR TITLE
Add file with Git hash for black code style commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# black code style on all files
+254c4a2658894c8c993a3921bec2580a6138b49b


### PR DESCRIPTION
https://www.michaelheap.com/git-ignore-rev/
Probably other commit hashes can be added to this file.

It may be nice to update the contributor documentation as well, since you need to configure this individually (or you may do it globally).

Please upvote this issue: https://github.com/github/feedback/discussions/5033 since GitHub doesn't support this feature, and will clutter the blame-feature with such commits.