### PR TITLE
Enable automatic dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "src/"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: "pip"
-    directory: "src/"
+    directory: "/src/"
     open-pull-requests-limit: 5
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: "pip"
-    directory: "/src/"
+    directory: "/"
     open-pull-requests-limit: 5
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     directory: "/"
     open-pull-requests-limit: 5
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
I think it became an opt-in feature of GitHub.

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates