### PR TITLE
Anonymous wiki through nginx (or other proxy)

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,6 +23,11 @@ Changed
 
 * Python-Markdown updated to 3.3 :url-issue:`1180` (Benjamin Balder Bach)
 
+Fixed
+~~~~~
+
+- Support for revision history w/ IP Address from ``HTTP_X_REAL_IP`` :url-issue:`1184` (David van Rijn)
+
 
 0.8.1
 -----

--- a/src/wiki/forms.py
+++ b/src/wiki/forms.py
@@ -125,8 +125,10 @@ class SpamProtectionMixin:
         if request.user.is_authenticated:
             user = request.user
         else:
-            ip_address = request.META.get("HTTP_X_REAL_IP", None) or request.META.get("REMOTE_ADDR", None) 
-            
+            ip_address = request.META.get("HTTP_X_REAL_IP", None) or request.META.get(
+                "REMOTE_ADDR", None
+            )
+
         if not (user or ip_address):
             raise forms.ValidationError(
                 gettext(

--- a/src/wiki/forms.py
+++ b/src/wiki/forms.py
@@ -125,8 +125,8 @@ class SpamProtectionMixin:
         if request.user.is_authenticated:
             user = request.user
         else:
-            ip_address = request.META.get("REMOTE_ADDR", None)
-
+            ip_address = request.META.get("HTTP_X_REAL_IP", None) or request.META.get("REMOTE_ADDR", None) 
+            
         if not (user or ip_address):
             raise forms.ValidationError(
                 gettext(


### PR DESCRIPTION
If you serve the wiki through ngingx, the remote ip is always empty, so 
i added the HTTP_X_REAL_IP header ass an alternative.