### PR TITLE
Fix double escaping of block code

### DIFF
--- a/src/wiki/core/markdown/mdx/codehilite.py
+++ b/src/wiki/core/markdown/mdx/codehilite.py
@@ -76,12 +76,24 @@ class WikiFencedBlockPreprocessor(Preprocessor):
 class HiliteTreeprocessor(Treeprocessor):
     """Hilight source code in code blocks."""
 
+    def code_unescape(self, text):
+        """Unescape &, <, > and " characters."""
+        text = text.replace("&amp;", "&")
+        text = text.replace("&lt;", "<")
+        text = text.replace("&gt;", ">")
+        text = text.replace("&quot;", '"')
+        return text
+
     def run(self, root):
         """Find code blocks and store in htmlStash."""
         blocks = root.iter("pre")
         for block in blocks:
             if len(block) == 1 and block[0].tag == "code":
-                html = highlight(block[0].text, self.config, self.markdown.tab_length)
+                html = highlight(
+                    self.code_unescape(block[0].text),
+                    self.config,
+                    self.markdown.tab_length,
+                )
                 placeholder = self.markdown.htmlStash.store(html)
                 # Clear codeblock in etree instance
                 block.clear()


### PR DESCRIPTION
I faced same issue as https://github.com/django-wiki/django-wiki/issues/945 and I was wondering why its was not merged so I made a Pull Request inspired by these piece of codes : https://github.com/Python-Markdown/markdown/pull/727 and https://github.com/jenda1/django-wiki/commit/07ea6d3360cd54cbbebc5291d34d58c5f3e8453f