### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ very easy, you don't even need to be a programmer.
 Some languages...
 
 * Just need a little push, as they are almost fully complete
-* Got initiatied and need a new instigator to carry on the ambitions
+* Got initiated and need a new instigator to carry on the ambitions
 * Do not exist yet - but you can request them and become the coordinator.
 
 `Visit the django-wiki project on Transifex <https://www.transifex.com/django-wiki/django-wiki/>`__

--- a/src/wiki/plugins/links/mdx/urlize.py
+++ b/src/wiki/plugins/links/mdx/urlize.py
@@ -38,7 +38,7 @@ import markdown
 #   in whitespace, ')', or '>'. If ')', then must match with '(' in
 #   BEGIN. If '>', then must match with '<' in BEGIN.
 #
-# It should be noted that there are some inconsitencies with the below
+# It should be noted that there are some inconsistencies with the below
 # regex, mainly that:
 #
 # - No IPv4 or IPv6 address validation is performed.


### PR DESCRIPTION
There are small typos in:
- README.rst
- src/wiki/plugins/links/mdx/urlize.py

Fixes:
- Should read `initiated` rather than `initiatied`.
- Should read `inconsistencies` rather than `inconsitencies`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md