### PR TITLE
moving sanitization to save rather than display

### DIFF
--- a/src/wiki/core/markdown/__init__.py
+++ b/src/wiki/core/markdown/__init__.py
@@ -30,26 +30,26 @@ class ArticleMarkdown(markdown.Markdown):
 
     def convert(self, text, *args, **kwargs):
         html = super().convert(text, *args, **kwargs)
-        if settings.MARKDOWN_SANITIZE_HTML:
-            tags = (
-                settings.MARKDOWN_HTML_WHITELIST + plugin_registry.get_html_whitelist()
-            )
+        # if settings.MARKDOWN_SANITIZE_HTML:
+        #     tags = (
+        #         settings.MARKDOWN_HTML_WHITELIST + plugin_registry.get_html_whitelist()
+        #     )
 
-            css_sanitizer = CSSSanitizer(
-                allowed_css_properties=settings.MARKDOWN_HTML_STYLES
-            )
+        #     css_sanitizer = CSSSanitizer(
+        #         allowed_css_properties=settings.MARKDOWN_HTML_STYLES
+        #     )
 
-            attrs = {}
-            attrs.update(settings.MARKDOWN_HTML_ATTRIBUTES)
-            attrs.update(plugin_registry.get_html_attributes().items())
+        #     attrs = {}
+        #     attrs.update(settings.MARKDOWN_HTML_ATTRIBUTES)
+        #     attrs.update(plugin_registry.get_html_attributes().items())
 
-            html = bleach.clean(
-                html,
-                tags=tags,
-                attributes=attrs,
-                css_sanitizer=css_sanitizer,
-                strip=True,
-            )
+        #     html = bleach.clean(
+        #         html,
+        #         tags=tags,
+        #         attributes=attrs,
+        #         css_sanitizer=css_sanitizer,
+        #         strip=True,
+        #     )
         return html
 
 

--- a/src/wiki/core/markdown/__init__.py
+++ b/src/wiki/core/markdown/__init__.py
@@ -1,7 +1,7 @@
 import bleach
 import markdown
-from bleach.css_sanitizer import CSSSanitizer
-from wiki.conf import settings
+# from bleach.css_sanitizer import CSSSanitizer
+# from wiki.conf import settings
 from wiki.core.plugins import registry as plugin_registry
 
 

--- a/src/wiki/core/markdown/__init__.py
+++ b/src/wiki/core/markdown/__init__.py
@@ -1,7 +1,7 @@
-import bleach
+# import bleach
 import markdown
 # from bleach.css_sanitizer import CSSSanitizer
-# from wiki.conf import settings
+from wiki.conf import settings
 from wiki.core.plugins import registry as plugin_registry
 
 

--- a/src/wiki/views/article.py
+++ b/src/wiki/views/article.py
@@ -92,7 +92,7 @@ class Create(FormView, ArticleMixin):
                 self.urlpath,
                 form.cleaned_data["slug"],
                 form.cleaned_data["title"],
-                form.cleaned_data["content"],
+                self.sanitize_html(form.cleaned_data["content"]),
                 form.cleaned_data["summary"],
             )
             messages.success(
@@ -370,7 +370,7 @@ class Edit(ArticleMixin, FormView):
         revision = models.ArticleRevision()
         revision.inherit_predecessor(self.article)
         revision.title = form.cleaned_data["title"]
-        revision.content = form.cleaned_data["content"]
+        revision.content = self.sanitize_html(form.cleaned_data["content"])
         revision.user_message = form.cleaned_data["summary"]
         revision.deleted = False
         revision.set_from_request(self.request)


### PR DESCRIPTION
First off, great work on this project!

I'm suggesting these changes to move the sanitization to the save of the content rather than at it's display.  The reason for this is because I'm hoping to write some plugins that do more dynamic things (e.g., have javascript, use html tags like button), and I don't want to disable or handicap the sanitization at all, since it is important to have.  So instead, I'm proposing you move the logic for sanitization to save, so that intended html created via plugins don't get stripped out.