### PR TITLE
Fix #1232 : global flags not at the start of the expression at position 9

### DIFF
--- a/src/wiki/plugins/images/markdown_extensions.py
+++ b/src/wiki/plugins/images/markdown_extensions.py
@@ -57,12 +57,11 @@ class ImagePattern(markdown.inlinepatterns.Pattern):
 
     def __init__(self, pattern, md=None):
         """Override init in order to add IGNORECASE and MULTILINE flags"""
-        self.pattern = pattern
+        super().__init__(pattern, md=md)
         self.compiled_re = re.compile(
             r"^(.*?)%s(.*)$" % pattern,
             flags=re.DOTALL | re.UNICODE | re.IGNORECASE | re.MULTILINE,
         )
-        self.md = md
 
     def handleMatch(self, m):
         image = None

--- a/src/wiki/plugins/images/markdown_extensions.py
+++ b/src/wiki/plugins/images/markdown_extensions.py
@@ -56,11 +56,11 @@ class ImagePattern(markdown.inlinepatterns.Pattern):
     """
 
     def __init__(self, pattern, md=None):
-        """ Override init in order to add IGNORECASE and MULTILINE flags """
+        """Override init in order to add IGNORECASE and MULTILINE flags"""
         self.pattern = pattern
         self.compiled_re = re.compile(
             r"^(.*?)%s(.*)$" % pattern,
-            flags=re.DOTALL | re.UNICODE | re.IGNORECASE | re.MULTILINE
+            flags=re.DOTALL | re.UNICODE | re.IGNORECASE | re.MULTILINE,
         )
         self.md = md
 

--- a/src/wiki/plugins/images/markdown_extensions.py
+++ b/src/wiki/plugins/images/markdown_extensions.py
@@ -1,3 +1,5 @@
+import re
+
 import markdown
 from django.template.loader import render_to_string
 from wiki.core.markdown import add_to_registry
@@ -5,7 +7,7 @@ from wiki.plugins.images import models
 from wiki.plugins.images import settings
 
 IMAGE_RE = (
-    r"(?:(?im)"
+    r"(?:"
     +
     # Match '[image:N'
     r"\[image\:(?P<id>[0-9]+)"
@@ -52,6 +54,15 @@ class ImagePattern(markdown.inlinepatterns.Pattern):
 
     So: Remember that the caption text is fully valid markdown!
     """
+
+    def __init__(self, pattern, md=None):
+        """ Override init in order to add IGNORECASE and MULTILINE flags """
+        self.pattern = pattern
+        self.compiled_re = re.compile(
+            r"^(.*?)%s(.*)$" % pattern,
+            flags=re.DOTALL | re.UNICODE | re.IGNORECASE | re.MULTILINE
+        )
+        self.md = md
 
     def handleMatch(self, m):
         image = None

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -34,11 +34,10 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
 
     def __init__(self, pattern, md=None):
         """Override init in order to add IGNORECASE flag"""
-        self.pattern = pattern
+        super().__init__(pattern, md=md)
         self.compiled_re = re.compile(
             r"^(.*?)%s(.*)$" % pattern, flags=re.DOTALL | re.UNICODE | re.IGNORECASE
         )
-        self.md = md
 
     def handleMatch(self, m):
         macro = m.group("macro").strip()

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -10,7 +10,7 @@ from wiki.plugins.macros import settings
 # http://stackoverflow.com/questions/430759/regex-for-managing-escaped-characters-for-items-like-string-literals
 re_sq_short = r"'([^'\\]*(?:\\.[^'\\]*)*)'"
 
-MACRO_RE = r"((?i)\[(?P<macro>\w+)(?P<kwargs>\s\w+\:.+)*\])"
+MACRO_RE = r"(\[(?P<macro>\w+)(?P<kwargs>\s\w+\:.+)*\])"
 KWARG_RE = re.compile(
     r"\s*(?P<arg>\w+)(:(?P<value>([^\']+|%s)))?" % re_sq_short, re.IGNORECASE
 )
@@ -31,6 +31,12 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
 
     """django-wiki macro preprocessor - parse text for various [some_macro] and
     [some_macro (kw:arg)*] references."""
+
+    def __init__(self, pattern, md=None):
+        """ Override init in order to add IGNORECASE flag """
+        self.pattern = pattern
+        self.compiled_re = re.compile(r"^(.*?)%s(.*)$" % pattern, flags=re.DOTALL | re.UNICODE | re.IGNORECASE)
+        self.md = md
 
     def handleMatch(self, m):
         macro = m.group("macro").strip()

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -33,9 +33,11 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
     [some_macro (kw:arg)*] references."""
 
     def __init__(self, pattern, md=None):
-        """ Override init in order to add IGNORECASE flag """
+        """Override init in order to add IGNORECASE flag"""
         self.pattern = pattern
-        self.compiled_re = re.compile(r"^(.*?)%s(.*)$" % pattern, flags=re.DOTALL | re.UNICODE | re.IGNORECASE)
+        self.compiled_re = re.compile(
+            r"^(.*?)%s(.*)$" % pattern, flags=re.DOTALL | re.UNICODE | re.IGNORECASE
+        )
         self.md = md
 
     def handleMatch(self, m):


### PR DESCRIPTION
I already migrated my project on Python 3.11 and I don't want to rollback just for the wiki module so I tried to find a fix for #1232

I first tried to remove global inline flags from the macro and image regular expressions, and the exception was gone. Then I overrode init functions from `Pattern` children classes in order to re-add the removed flags in the `compile` function.


Unfortunately, I wasn't able to run tests with hatch (I am on Windows and it uses sh commands).