### PR TITLE
Rework editsection plugin (fixes #1246)

### DIFF
--- a/src/wiki/core/markdown/__init__.py
+++ b/src/wiki/core/markdown/__init__.py
@@ -13,6 +13,7 @@ class ArticleMarkdown(markdown.Markdown):
         self.article = article
         self.preview = preview
         self.user = user
+        self.source = None
 
     def core_extensions(self):
         """List of core extensions found in the mdx folder"""
@@ -29,6 +30,8 @@ class ArticleMarkdown(markdown.Markdown):
         return extensions
 
     def convert(self, text, *args, **kwargs):
+        # store source in instance, for extensions which might need it
+        self.source = text
         html = super().convert(text, *args, **kwargs)
         if settings.MARKDOWN_SANITIZE_HTML:
             tags = (

--- a/src/wiki/plugins/editsection/markdown_extensions.py
+++ b/src/wiki/plugins/editsection/markdown_extensions.py
@@ -1,128 +1,157 @@
-import re
+import re, logging
 
 from django.urls import reverse
 from markdown import Extension
 from markdown.treeprocessors import Treeprocessor
-from markdown.util import etree
+from markdown.blockprocessors import HashHeaderProcessor, SetextHeaderProcessor
+from xml.etree import ElementTree as etree
 from wiki.core.markdown import add_to_registry
+from wiki.plugins.macros.mdx.toc import wiki_slugify
 
 from . import settings
+
+
+logger = logging.getLogger('MARKDOWN')
+
+
+class CustomHashHeaderProcessor(HashHeaderProcessor):
+    """
+    Custom HashHeaderProcessor. The only difference to the upstream
+    processor is that we set the data-block-source attribute on any
+    inserted header.
+    """
+    def run(self, parent, blocks):
+        block = blocks.pop(0)
+        m = self.RE.search(block)
+        if m:
+            before = block[:m.start()]  # All lines before header
+            after = block[m.end():]     # All lines after header
+            if before:
+                # As the header was not the first line of the block and the
+                # lines before the header must be parsed first,
+                # recursively parse this lines as a block.
+                self.parser.parseBlocks(parent, [before])
+            # Create header using named groups from RE
+            h = etree.SubElement(parent, 'h%d' % len(m.group('level')))
+            h.text = m.group('header').strip()
+            h.attrib['data-block-source'] = m.group().strip()
+            if after:
+                # Insert remaining lines as first block for future parsing.
+                blocks.insert(0, after)
+        else:  # pragma: no cover
+            # This should never happen, but just in case...
+            logger.warning("We've got a problem header: %r" % block)
+
+
+class CustomSetextHeaderProcessor(SetextHeaderProcessor):
+    """
+    Custom SetextHeaderProcessor. The only difference to the upstream
+    processor is that we set the data-block-source attribute on any
+    inserted header.
+    """
+    def run(self, parent, blocks):
+        lines = blocks.pop(0).split('\n')
+        # Determine level. ``=`` is 1 and ``-`` is 2.
+        if lines[1].startswith('='):
+            level = 1
+        else:
+            level = 2
+        h = etree.SubElement(parent, 'h%d' % level)
+        h.text = lines[0].strip()
+        h.attrib['data-block-source'] = '\r\n'.join(lines)
+        if len(lines) > 2:
+            # Block contains additional lines. Add to  master blocks for later.
+            blocks.insert(0, '\n'.join(lines[2:]))
 
 
 class EditSectionExtension(Extension):
     def __init__(self, *args, **kwargs):
         self.config = {
-            "level": [settings.MAX_LEVEL, "Allow to edit sections until this level"],
-            "headers": None,  # List of FindHeader, all headers with there positions
-            "location": None,  # To be extracted header
-            "header_id": None,  # Header text ID of the to be extracted header
+            "level": [settings.MAX_LEVEL, "Allow to edit sections until this level"]
         }
         super().__init__(**kwargs)
 
     def extendMarkdown(self, md):
-        ext = EditSectionProcessor(md)
-        ext.config = self.config
-
-        add_to_registry(md.treeprocessors, "editsection", ext, "_end")
-
-
-def get_header_id(header):
-    header_id = "".join(w[0] for w in re.findall(r"\w+", str(header)))
-    if not len(header_id):
-        return "_"
-    return header_id
+        # replace HashHeader/SetextHeader processors with our custom variants
+        md.parser.blockprocessors.register(CustomHashHeaderProcessor(md.parser), 'hashheader', 70)
+        md.parser.blockprocessors.register(CustomSetextHeaderProcessor(md.parser), 'setextheader', 60)
+        # the tree processor adds the actual edit links
+        add_to_registry(md.treeprocessors, "editsection", EditSectionProcessor(self.config, md), "_end")
 
 
 class EditSectionProcessor(Treeprocessor):
-    def locate_section(self, node):
-        cur_pos = [0] * self.level
-        last_level = 0
-        cur_header = -1
-        sec_level = -1
-        sec_start = -1
+    """
+    TreeProcessor adds the edit links for every header which has a data-block-source attribute
+    """
+    def __init__(self, config, md=None):
+        self.config = config
+        self.slugs = {}         # keep found slugs (to ensure uniqueness)
+        self.source = None      # will be set in run()
+        self.last_start = 0     # location of last inserted edit link
+        super().__init__(md)
 
-        for child in list(node):
-            match = self.HEADER_RE.match(child.tag.lower())
-            if not match:
-                continue
-
-            level = int(match.group(1))
-
-            # Find current position in headers
-            cur_header += 1
-            while (
-                cur_header < len(self.headers)
-                and not self.headers[cur_header].sure_header
-                and child.text != self.headers[cur_header].header
-            ):
-                cur_header += 1
-            if cur_header >= len(self.headers):
-                return None
-
-            # End of the searched section found?
-            if level <= sec_level:
-                return sec_start, self.headers[cur_header].start
-
-            for _l in range(level, last_level):
-                cur_pos[_l] = 0
-            cur_pos[level - 1] += 1
-            last_level = level
-
-            location = "-".join(map(str, cur_pos))
-            if location != self.location:
-                continue
-
-            # Found section start. Check if the header id text is still correct.
-            if get_header_id(child.text) != self.header_id:
-                return None
-
-            # Correct section start found. Search now for the section end.
-            sec_level = level
-            sec_start = self.headers[cur_header].start
-
-        if sec_start >= 0:
-            return sec_start, 9999999
-        return None
+    def ensure_unique_id(self, node):
+        """ ensures that node has a unique id, preferring an already existing id """
+        if 'id' in node.attrib:
+            slug = node.attrib['id']
+        else:
+            content = node.text.strip()
+            slug = wiki_slugify(content, '-', unicode=True)
+        candidate = slug
+        i = 1
+        while candidate in self.slugs:
+            candidate = '{}_{}'.format(slug, i)
+            i += 1
+        self.slugs[candidate] = True
+        node.attrib['id'] = candidate
+        return candidate
 
     def add_links(self, node):
-        cur_pos = [0] * self.level
-        last_level = 0
-
+        headers = []
         for child in list(node):
             match = self.HEADER_RE.match(child.tag.lower())
             if not match:
                 continue
+            level = match.group(1)
 
-            level = int(match.group(1))
-            for _l in range(level, last_level):
-                cur_pos[_l] = 0
-            cur_pos[level - 1] += 1
-            last_level = level
-            location = "-".join(map(str, cur_pos))
-            header_id = get_header_id(child.text)
+            if 'data-block-source' in child.attrib:
+                source_block = child.attrib['data-block-source']
+                del child.attrib['data-block-source']
+                # locate in document source
+                start = self.source.find(source_block, self.last_start)
+                if start == -1:
+                    # not found in source, ignore
+                    continue
 
-            # Insert link to allow editing this section
-            link = etree.SubElement(child, "a")
-            link.text = settings.LINK_TEXT
-            link.attrib["class"] = "article-edit-title-link"
+                # ensure that the node has a unique id
+                slug = self.ensure_unique_id(child)
 
-            # Build the URL
-            url_kwargs = self.md.article.get_url_kwargs()
-            url_kwargs["location"] = location
-            url_kwargs["header"] = header_id
-            link.attrib["href"] = reverse("wiki:editsection", kwargs=url_kwargs)
+                # Insert link to allow editing this section
+                link = etree.SubElement(child, "a")
+                link.text = settings.LINK_TEXT
+                link.attrib["class"] = "article-edit-title-link"
+
+                 # Build the URL
+                url_kwargs = self.md.article.get_url_kwargs()
+                url_kwargs["header"] = child.attrib['id']
+                link.attrib["href"] = reverse("wiki:editsection", kwargs=url_kwargs)
+
+                headers.append({
+                    'slug': slug,
+                    'position': start,
+                    'level': level,
+                    'source': source_block
+                })
+        return headers
 
     def run(self, root):
         self.level = self.config.get("level")[0]
+        self.article = self.md.article
+        self.source = self.md.source
         self.HEADER_RE = re.compile(
             "^h([" + "".join(map(str, range(1, self.level + 1))) + "])"
         )
-        self.headers = self.config.get("headers")
-        if self.headers:
-            self.location = self.config.get("location")
-            self.header_id = self.config.get("header_id")
-            self.config["location"] = self.locate_section(root)
-            self.config["headers"] = None
-        else:
-            self.add_links(root)
+        headers = self.add_links(root)
+        # store found headers at article, for use in edit view
+        self.article._found_headers = headers
         return root

--- a/src/wiki/plugins/editsection/markdown_extensions.py
+++ b/src/wiki/plugins/editsection/markdown_extensions.py
@@ -3,7 +3,8 @@ import re, logging
 from django.urls import reverse
 from markdown import Extension
 from markdown.treeprocessors import Treeprocessor
-from markdown.blockprocessors import HashHeaderProcessor, SetextHeaderProcessor
+from markdown.blockprocessors import HashHeaderProcessor
+from markdown.blockprocessors import SetextHeaderProcessor
 from xml.etree import ElementTree as etree
 from wiki.core.markdown import add_to_registry
 from wiki.plugins.macros.mdx.toc import wiki_slugify
@@ -131,7 +132,7 @@ class EditSectionProcessor(Treeprocessor):
                 link.text = settings.LINK_TEXT
                 link.attrib["class"] = "article-edit-title-link"
 
-                 # Build the URL
+                # Build the URL
                 url_kwargs = self.md.article.get_url_kwargs()
                 url_kwargs["header"] = child.attrib['id']
                 link.attrib["href"] = reverse("wiki:editsection", kwargs=url_kwargs)

--- a/src/wiki/plugins/editsection/markdown_extensions.py
+++ b/src/wiki/plugins/editsection/markdown_extensions.py
@@ -1,4 +1,5 @@
-import re, logging
+import re
+import logging
 
 from django.urls import reverse
 from markdown import Extension

--- a/src/wiki/plugins/editsection/markdown_extensions.py
+++ b/src/wiki/plugins/editsection/markdown_extensions.py
@@ -136,6 +136,7 @@ class EditSectionProcessor(Treeprocessor):
                 if start == -1:
                     # not found in source, ignore
                     continue
+                self.last_start = start + 1
 
                 # ensure that the node has a unique id
                 slug = self.ensure_unique_id(child)

--- a/src/wiki/plugins/editsection/markdown_extensions.py
+++ b/src/wiki/plugins/editsection/markdown_extensions.py
@@ -1,7 +1,5 @@
 import logging
 import re
-from wiki.core.markdown import add_to_registry
-from wiki.plugins.macros.mdx.toc import wiki_slugify
 from xml.etree import ElementTree as etree
 
 from django.urls import reverse
@@ -9,6 +7,8 @@ from markdown import Extension
 from markdown.blockprocessors import HashHeaderProcessor
 from markdown.blockprocessors import SetextHeaderProcessor
 from markdown.treeprocessors import Treeprocessor
+from wiki.core.markdown import add_to_registry
+from wiki.plugins.macros.mdx.toc import wiki_slugify
 
 from . import settings
 

--- a/src/wiki/plugins/editsection/views.py
+++ b/src/wiki/plugins/editsection/views.py
@@ -1,12 +1,13 @@
+from wiki import models
+from wiki.core.markdown import article_markdown
+from wiki.decorators import get_article
+from wiki.views.article import Edit as EditView
+
 from django.contrib import messages
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
-from wiki import models
-from wiki.core.markdown import article_markdown
-from wiki.decorators import get_article
-from wiki.views.article import Edit as EditView
 
 
 ERROR_SECTION_CHANGED = gettext_lazy(
@@ -24,21 +25,20 @@ ERROR_TRY_AGAIN = gettext_lazy("Please try again.")
 
 
 class EditSection(EditView):
-
     def locate_section(self, article, content):
         """
         locate the section to be edited, returning index of start and end
         """
         # render article to get the headers
         article_markdown(content, article)
-        headers = getattr(article, '_found_headers', [])
+        headers = getattr(article, "_found_headers", [])
 
         # find start
         start, end = None, None
         while len(headers):
             header = headers.pop(0)
-            if header['slug'] == self.header_id:
-                if content[header['position']:].startswith(header['source']):
+            if header["slug"] == self.header_id:
+                if content[header["position"] :].startswith(header["source"]):
                     start = header
                     break
         if start is None:
@@ -48,15 +48,19 @@ class EditSection(EditView):
         # we have the beginning, now find next section with same or higher level
         while len(headers):
             header = headers.pop(0)
-            if header['level'] <= start['level']:
-                if content[header['position']:].startswith(header['source']):
+            if header["level"] <= start["level"]:
+                if content[header["position"] :].startswith(header["source"]):
                     end = header
                     break
                 else:
                     # there should be a matching header, but we did not find it.
                     # better be safe.
                     return None, None
-        return (start['position'], end['position']) if end else (start['position'], len(content))
+        return (
+            (start["position"], end["position"])
+            if end
+            else (start["position"], len(content))
+        )
 
     def _redirect_to_article(self):
         if self.urlpath:

--- a/src/wiki/plugins/editsection/views.py
+++ b/src/wiki/plugins/editsection/views.py
@@ -1,13 +1,12 @@
-from wiki import models
-from wiki.core.markdown import article_markdown
-from wiki.decorators import get_article
-from wiki.views.article import Edit as EditView
-
 from django.contrib import messages
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
+from wiki import models
+from wiki.core.markdown import article_markdown
+from wiki.decorators import get_article
+from wiki.views.article import Edit as EditView
 
 
 ERROR_SECTION_CHANGED = gettext_lazy(

--- a/src/wiki/plugins/editsection/views.py
+++ b/src/wiki/plugins/editsection/views.py
@@ -56,7 +56,7 @@ class EditSection(EditView):
                     # there should be a matching header, but we did not find it.
                     # better be safe.
                     return None, None
-        return ( start['position'], end['position'] ) if end else ( start['position'], len(content) )
+        return (start['position'], end['position']) if end else (start['position'], len(content))
 
     def _redirect_to_article(self):
         if self.urlpath:

--- a/src/wiki/plugins/editsection/views.py
+++ b/src/wiki/plugins/editsection/views.py
@@ -1,5 +1,3 @@
-import re
-
 from django.contrib import messages
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
@@ -7,12 +5,9 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
 from wiki import models
 from wiki.core.markdown import article_markdown
-from wiki.core.plugins.registry import get_markdown_extensions
 from wiki.decorators import get_article
-from wiki.plugins.editsection.markdown_extensions import EditSectionExtension
 from wiki.views.article import Edit as EditView
 
-from . import settings
 
 ERROR_SECTION_CHANGED = gettext_lazy(
     "Unable to find the selected section. The article was modified meanwhile."
@@ -28,86 +23,40 @@ ERROR_ARTICLE_CHANGED = gettext_lazy(
 ERROR_TRY_AGAIN = gettext_lazy("Please try again.")
 
 
-class FindHeader:
-    """Locate the start, header text, and end of the header text of the next
-    possible section starting from pos. Finds too many occurrences for SeText
-    headers which are filtered out later in the markdown extension.
-    Returns: start pos header sure_header level"""
-
-    SETEXT_RE_TEXT = r"(?P<header1>.*?)\n(?P<level1>[=-])+[ ]*(\n|$)"
-    SETEXT_RE = re.compile(r"\n%s" % SETEXT_RE_TEXT, re.MULTILINE)
-    HEADER_RE = re.compile(
-        r"((\A ?\n?|\n(?![^\n]{0,3}\w).*?\n)%s"
-        r"|(\A|\n)(?P<level2>#{1,6})(?P<header2>.*?)#*(\n|$))" % SETEXT_RE_TEXT,
-        re.MULTILINE,
-    )
-    ATTR_RE = re.compile(r"[ ]+\{\:?([^\}\n]*)\}[ ]*$")
-
-    def __init__(self, text, pos):
-        self.sure_header = False
-        match = self.SETEXT_RE.match(text, pos)
-        if match:
-            self.sure_header = True
-        else:
-            match = self.HEADER_RE.search(text, pos)
-            if not match:
-                self.start = len(text) + 1
-                self.pos = self.start
-                return
-        self.pos = match.end() - 1
-
-        # Get level and header text of the section
-        token = match.group("level1")
-        if token:
-            self.header = match.group("header1").strip()
-            self.start = match.start("header1")
-        else:
-            token = match.group("level2")
-            self.header = match.group("header2").strip()
-            self.start = match.start("level2")
-            self.sure_header = True
-        # Remove attribute definitions from the header text
-        match = self.ATTR_RE.search(self.header)
-        if match:
-            self.header = self.header[: match.start()].rstrip("#").rstrip()
-        # Get level of the section
-        if token[0] == "=":
-            self.level = 1
-        elif token[0] == "-":
-            self.level = 2
-        else:
-            self.level = len(token)
-
-
 class EditSection(EditView):
-    def locate_section(self, article, text):
-        """Search for the header self.location (which is not deeper than settings.MAX_LEVEL)
-        in text, compare the header text with self.header_id, and return the start position
-        and the end position+1 of the complete section started by the header.
+
+    def locate_section(self, article, content):
         """
-        text = text.replace("\r\n", " \n").replace("\r", "\n") + "\n\n"
-        text_len = len(text)
+        locate the section to be edited, returning index of start and end
+        """
+        # render article to get the headers
+        article_markdown(content, article)
+        headers = getattr(article, '_found_headers', [])
 
-        headers = []
-        pos = 0
-        while pos < text_len:
-            # Get meta information and start position of the next section
-            header = FindHeader(text, pos)
-            pos = header.pos
-            if pos >= text_len:
-                break
-            if header.level > settings.MAX_LEVEL:
-                continue
-            headers.append(header)
+        # find start
+        start, end = None, None
+        while len(headers):
+            header = headers.pop(0)
+            if header['slug'] == self.header_id:
+                if content[header['position']:].startswith(header['source']):
+                    start = header
+                    break
+        if start is None:
+            # start section not found
+            return None, None
 
-        for e in get_markdown_extensions():
-            if isinstance(e, EditSectionExtension):
-                e.config["headers"] = headers
-                e.config["location"] = self.location
-                e.config["header_id"] = self.header_id
-                article_markdown(text, article)
-                return e.config["location"]
-        return None
+        # we have the beginning, now find next section with same or higher level
+        while len(headers):
+            header = headers.pop(0)
+            if header['level'] <= start['level']:
+                if content[header['position']:].startswith(header['source']):
+                    end = header
+                    break
+                else:
+                    # there should be a matching header, but we did not find it.
+                    # better be safe.
+                    return None, None
+        return ( start['position'], end['position'] ) if end else ( start['position'], len(content) )
 
     def _redirect_to_article(self):
         if self.urlpath:
@@ -116,18 +65,15 @@ class EditSection(EditView):
 
     @method_decorator(get_article(can_write=True, not_locked=True))
     def dispatch(self, request, article, *args, **kwargs):
-        self.location = kwargs.pop("location", 0)
         self.header_id = kwargs.pop("header", 0)
-
         self.urlpath = kwargs.get("urlpath")
         kwargs["path"] = self.urlpath.path
+        content = article.current_revision.content
 
         if request.method == "GET":
-            text = article.current_revision.content
-            location = self.locate_section(article, text)
-            if location:
-                self.orig_section = text[location[0] : location[1]]
-                # Pass the to be used content to EditSection
+            start, end = self.locate_section(article, content)
+            if start is not None and end is not None:
+                self.orig_section = content[start:end]
                 kwargs["content"] = self.orig_section
                 request.session["editsection_content"] = self.orig_section
             else:
@@ -147,15 +93,16 @@ class EditSection(EditView):
         section = self.article.current_revision.content
         if not section.endswith("\n"):
             section += "\r\n\r\n"
-        text = get_object_or_404(
+        content = get_object_or_404(
             models.ArticleRevision,
             article=self.article,
             id=self.article.current_revision.previous_revision.id,
         ).content
-
-        location = self.locate_section(self.article, text)
-        if location:
-            if self.orig_section != text[location[0] : location[1]]:
+        start, end = self.locate_section(self.article, content)
+        if start is not None and end is not None:
+            # compare saved original section with last version, so we
+            # can detect if someone else changed it in the meantime
+            if self.orig_section != content[start:end]:
                 messages.warning(
                     self.request,
                     "{} {} {}".format(
@@ -164,7 +111,7 @@ class EditSection(EditView):
                 )
             # Include the edited section into the complete previous article
             self.article.current_revision.content = (
-                text[0 : location[0]] + section + text[location[1] :]
+                content[0:start] + section + content[end:]
             )
             self.article.current_revision.save()
         else:

--- a/src/wiki/plugins/editsection/wiki_plugin.py
+++ b/src/wiki/plugins/editsection/wiki_plugin.py
@@ -13,7 +13,7 @@ class EditSectionPlugin(BasePlugin):
     urlpatterns = {
         "article": [
             url(
-                r"^(?P<location>[0-9-]+)/header/(?P<header>\w+)/$",
+                r"^header/(?P<header>[\w-]+)/$",
                 views.EditSection.as_view(),
                 name="editsection",
             ),

--- a/tests/plugins/editsection/test_editsection.py
+++ b/tests/plugins/editsection/test_editsection.py
@@ -108,7 +108,7 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
 
     def test_sourceblock_with_comment(self):
         # https://github.com/django-wiki/django-wiki/issues/1246
-        urlpath = URLPath.create_urlpath(
+        URLPath.create_urlpath(
             URLPath.root(), "testedit_src", title="TestEditSourceComment", content=TEST_CONTENT_SRC_COMMENT
         )
         url = reverse(

--- a/tests/plugins/editsection/test_editsection.py
+++ b/tests/plugins/editsection/test_editsection.py
@@ -1,8 +1,8 @@
 import re
-from wiki.models import URLPath
 
 from django.urls import reverse
 from django_functest import FuncBaseMixin
+from wiki.models import URLPath
 
 from ...base import DjangoClientTestBase
 from ...base import RequireRootArticleMixin

--- a/tests/plugins/editsection/test_editsection.py
+++ b/tests/plugins/editsection/test_editsection.py
@@ -1,7 +1,8 @@
 import re
+from wiki.models import URLPath
+
 from django.urls import reverse
 from django_functest import FuncBaseMixin
-from wiki.models import URLPath
 
 from ...base import DjangoClientTestBase
 from ...base import RequireRootArticleMixin
@@ -100,23 +101,27 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
 
     def get_section_content(self, response):
         # extract actual section content from response (editor)
-        m = re.search(r'<textarea[^>]+>(?P<content>[^<]+)</textarea>', response.rendered_content, re.DOTALL)
+        m = re.search(
+            r"<textarea[^>]+>(?P<content>[^<]+)</textarea>",
+            response.rendered_content,
+            re.DOTALL,
+        )
         if m:
-            return m.group('content')
+            return m.group("content")
         else:
-            return ''
+            return ""
 
     def test_sourceblock_with_comment(self):
         # https://github.com/django-wiki/django-wiki/issues/1246
         URLPath.create_urlpath(
-            URLPath.root(), "testedit_src", title="TestEditSourceComment", content=TEST_CONTENT_SRC_COMMENT
+            URLPath.root(),
+            "testedit_src",
+            title="TestEditSourceComment",
+            content=TEST_CONTENT_SRC_COMMENT,
         )
         url = reverse(
             "wiki:editsection",
-            kwargs={
-                "path": "testedit_src/",
-                "header": "wiki-toc-section-2"
-            },
+            kwargs={"path": "testedit_src/", "header": "wiki-toc-section-2"},
         )
         response = self.client.get(url)
         actual = self.get_section_content(response)
@@ -124,17 +129,17 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
         self.assertEqual(actual, expected)
 
     def test_nonunique_headers(self):
-        """ test whether non-unique headers will be handled properly """
+        """test whether non-unique headers will be handled properly"""
         source = """# Investigation 1\n\n## Date\n2023-01-01\n\n# Investigation 2\n\n## Date\n2023-01-02"""
         URLPath.create_urlpath(
-            URLPath.root(), "testedit_src", title="TestEditSourceComment", content=source
+            URLPath.root(),
+            "testedit_src",
+            title="TestEditSourceComment",
+            content=source,
         )
         url = reverse(
             "wiki:editsection",
-            kwargs={
-                "path": "testedit_src/",
-                "header": "wiki-toc-date"
-            },
+            kwargs={"path": "testedit_src/", "header": "wiki-toc-date"},
         )
         response = self.client.get(url)
         actual = self.get_section_content(response)
@@ -143,10 +148,7 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
         self.assertEqual(actual, expected)
         url = reverse(
             "wiki:editsection",
-            kwargs={
-                "path": "testedit_src/",
-                "header": "wiki-toc-date_1"
-            },
+            kwargs={"path": "testedit_src/", "header": "wiki-toc-date_1"},
         )
         response = self.client.get(url)
         actual = self.get_section_content(response)

--- a/tests/plugins/editsection/test_editsection.py
+++ b/tests/plugins/editsection/test_editsection.py
@@ -1,3 +1,4 @@
+import re
 from django.urls import reverse
 from django_functest import FuncBaseMixin
 from wiki.models import URLPath
@@ -21,6 +22,20 @@ TEST_CONTENT = (
 )
 
 
+TEST_CONTENT_SRC_COMMENT = """
+# Section 1
+Section 1 Lorem ipsum dolor sit amet
+
+```python
+# hello world
+print("hello world")
+```
+
+# Section 2
+Section 2 Lorem ipsum dolor sit amet
+"""
+
+
 class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
     def test_editsection(self):
         # Test creating links to allow editing all sections individually
@@ -30,19 +45,19 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
         output = urlpath.article.render()
         expected = (
             r"(?s)"
-            r'Title 1<a class="article-edit-title-link" href="/testedit/_plugin/editsection/1-0-0/header/T1/">\[edit\]</a>.*'
-            r'Title 2<a class="article-edit-title-link" href="/testedit/_plugin/editsection/1-1-0/header/T2/">\[edit\]</a>.*'
-            r'Title 3<a class="article-edit-title-link" href="/testedit/_plugin/editsection/1-2-0/header/T3/">\[edit\]</a>.*'
-            r'Title 4<a class="article-edit-title-link" href="/testedit/_plugin/editsection/1-2-1/header/T4/">\[edit\]</a>.*'
-            r'Title 5<a class="article-edit-title-link" href="/testedit/_plugin/editsection/1-3-0/header/T5/">\[edit\]</a>.*'
-            r'Title 6<a class="article-edit-title-link" href="/testedit/_plugin/editsection/2-0-0/header/T6/">\[edit\]</a>.*'
+            r'Title 1<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-1/">\[edit\]</a>.*'
+            r'Title 2<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-2/">\[edit\]</a>.*'
+            r'Title 3<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-3/">\[edit\]</a>.*'
+            r'Title 4<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-4/">\[edit\]</a>.*'
+            r'Title 5<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-5/">\[edit\]</a>.*'
+            r'Title 6<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-6/">\[edit\]</a>.*'
         )
         self.assertRegex(output, expected)
 
         # Test wrong header text. Editing should fail with a redirect.
         url = reverse(
             "wiki:editsection",
-            kwargs={"path": "testedit/", "location": "1-2-1", "header": "Test"},
+            kwargs={"path": "testedit/", "header": "does-not-exist"},
         )
         response = self.client.get(url)
         self.assertRedirects(
@@ -52,7 +67,7 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
         # Test extracting sections for editing
         url = reverse(
             "wiki:editsection",
-            kwargs={"path": "testedit/", "location": "1-2-1", "header": "T4"},
+            kwargs={"path": "testedit/", "header": "wiki-toc-title-4"},
         )
         response = self.client.get(url)
         expected = ">### Title 4[\r\n]*" "<"
@@ -60,7 +75,7 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
 
         url = reverse(
             "wiki:editsection",
-            kwargs={"path": "testedit/", "location": "1-2-0", "header": "T3"},
+            kwargs={"path": "testedit/", "header": "wiki-toc-title-3"},
         )
         response = self.client.get(url)
         expected = (
@@ -83,6 +98,31 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
         output = urlpath.article.render()
         print(output)
 
+    def get_section_content(self, response):
+        # extract actual section content from response (editor)
+        m = re.search(r'<textarea[^>]+>(?P<content>[^<]+)</textarea>', response.rendered_content, re.DOTALL)
+        if m:
+            return m.group('content')
+        else:
+            return ''
+
+    def test_sourceblock_with_comment(self):
+        # https://github.com/django-wiki/django-wiki/issues/1246
+        urlpath = URLPath.create_urlpath(
+            URLPath.root(), "testedit_src", title="TestEditSourceComment", content=TEST_CONTENT_SRC_COMMENT
+        )
+        url = reverse(
+            "wiki:editsection",
+            kwargs={
+                "path": "testedit_src/",
+                "header": "wiki-toc-section-2"
+            },
+        )
+        response = self.client.get(url)
+        actual = self.get_section_content(response)
+        expected = "# Section 2\r\nSection 2 Lorem ipsum dolor sit amet\r\n"
+        self.assertEqual(actual, expected)
+
 
 class EditSectionEditBase(RequireRootArticleMixin, FuncBaseMixin):
     pass
@@ -99,19 +139,19 @@ class EditSectionEditTests(EditSectionEditBase, WebTestBase):
         self.get_literal_url(
             reverse(
                 "wiki:editsection",
-                kwargs={"path": "testedit/", "location": "1-2-0", "header": "T3"},
+                kwargs={"path": "testedit/", "header": "wiki-toc-title-3"},
             )
         )
         self.fill({"#id_content": "# Header 1\nContent of the new section"})
         self.submit("#id_save")
         expected = (
             r"(?s)"
-            r'Title 1<a class="article-edit-title-link" href="/testedit/_plugin/editsection/1-0-0/header/T1/">\[edit\]</a>.*'
-            r'Title 2<a class="article-edit-title-link" href="/testedit/_plugin/editsection/1-1-0/header/T2/">\[edit\]</a>.*'
-            r'Header 1<a class="article-edit-title-link" href="/testedit/_plugin/editsection/2-0-0/header/H1/">\[edit\]</a>.*'
+            r'Title 1<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-1/">\[edit\]</a>.*'
+            r'Title 2<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-2/">\[edit\]</a>.*'
+            r'Header 1<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-header-1/">\[edit\]</a>.*'
             r"Content of the new section.*"
-            r'Title 5<a class="article-edit-title-link" href="/testedit/_plugin/editsection/2-1-0/header/T5/">\[edit\]</a>.*'
-            r'Title 6<a class="article-edit-title-link" href="/testedit/_plugin/editsection/3-0-0/header/T6/">\[edit\]</a>.*'
+            r'Title 5<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-5/">\[edit\]</a>.*'
+            r'Title 6<a class="article-edit-title-link" href="/testedit/_plugin/editsection/header/wiki-toc-title-6/">\[edit\]</a>.*'
         )
         self.assertRegex(self.last_response.content.decode("utf-8"), expected)
 

--- a/tests/plugins/editsection/test_editsection.py
+++ b/tests/plugins/editsection/test_editsection.py
@@ -123,6 +123,36 @@ class EditSectionTests(RequireRootArticleMixin, DjangoClientTestBase):
         expected = "# Section 2\r\nSection 2 Lorem ipsum dolor sit amet\r\n"
         self.assertEqual(actual, expected)
 
+    def test_nonunique_headers(self):
+        """ test whether non-unique headers will be handled properly """
+        source = """# Investigation 1\n\n## Date\n2023-01-01\n\n# Investigation 2\n\n## Date\n2023-01-02"""
+        URLPath.create_urlpath(
+            URLPath.root(), "testedit_src", title="TestEditSourceComment", content=source
+        )
+        url = reverse(
+            "wiki:editsection",
+            kwargs={
+                "path": "testedit_src/",
+                "header": "wiki-toc-date"
+            },
+        )
+        response = self.client.get(url)
+        actual = self.get_section_content(response)
+        expected = "## Date\r\n2023-01-01\r\n\r\n"
+
+        self.assertEqual(actual, expected)
+        url = reverse(
+            "wiki:editsection",
+            kwargs={
+                "path": "testedit_src/",
+                "header": "wiki-toc-date_1"
+            },
+        )
+        response = self.client.get(url)
+        actual = self.get_section_content(response)
+        expected = "## Date\r\n2023-01-02"
+        self.assertEqual(actual, expected)
+
 
 class EditSectionEditBase(RequireRootArticleMixin, FuncBaseMixin):
     pass


### PR DESCRIPTION
The main problem of editsection is to find the correct location of the section to edit in the source. Previously, that was done with custom, regex-based parsing, but that fails when code blocks contain lines which look like a header (for example, python comments).

This patch uses another approach to find the correct sections. It uses extended versions of the BlockParsers responsible for creating headers, which annotate those headers with the consumed source block. Since we know now which input was responsible for generating the header, we can easily locate it in the markdown source.