### PR TITLE
Pass current revision to Editor.get_widget()/get_admin_widget()

### DIFF
--- a/src/wiki/admin.py
+++ b/src/wiki/admin.py
@@ -24,7 +24,7 @@ class ArticleRevisionForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         # TODO: This pattern is too weird
         editor = editors.getEditor()
-        self.fields["content"].widget = editor.get_admin_widget()
+        self.fields["content"].widget = editor.get_admin_widget(self.instance)
 
 
 class ArticleRevisionAdmin(admin.ModelAdmin):

--- a/src/wiki/editors/base.py
+++ b/src/wiki/editors/base.py
@@ -11,10 +11,10 @@ class BaseEditor:
     media_admin = ()
     media_frontend = ()
 
-    def __init__(self, instance=None):
-        self.instance = instance
+    def get_admin_widget(self, revision=None):
+        return forms.Textarea()
 
-    def get_admin_widget(self):
+    def get_widget(self, revision=None):
         return forms.Textarea()
 
     class AdminMedia:

--- a/src/wiki/editors/markitup.py
+++ b/src/wiki/editors/markitup.py
@@ -26,10 +26,10 @@ class MarkItUpAdminWidget(MarkItUpWidget):
 class MarkItUp(BaseEditor):
     editor_id = "markitup"
 
-    def get_admin_widget(self, instance=None):
+    def get_admin_widget(self, revision=None):
         return MarkItUpAdminWidget()
 
-    def get_widget(self, instance=None):
+    def get_widget(self, revision=None):
         return MarkItUpWidget()
 
     class AdminMedia:

--- a/src/wiki/forms.py
+++ b/src/wiki/forms.py
@@ -227,9 +227,7 @@ class EditForm(forms.Form, SpamProtectionMixin):
     title = forms.CharField(
         label=_("Title"),
     )
-    content = forms.CharField(
-        label=_("Contents"), required=False, widget=getEditor().get_widget()
-    )  # @UndefinedVariable
+    content = forms.CharField(label=_("Contents"), required=False)  # @UndefinedVariable
 
     summary = forms.CharField(
         label=pgettext_lazy("Revision comment", "Summary"),
@@ -294,6 +292,7 @@ class EditForm(forms.Form, SpamProtectionMixin):
             kwargs["initial"] = initial
 
         super().__init__(*args, **kwargs)
+        self.fields["content"].widget = getEditor().get_widget(current_revision)
 
     def clean_title(self):
         title = self.cleaned_data.get("title", None)

--- a/tests/core/test_editor.py
+++ b/tests/core/test_editor.py
@@ -1,0 +1,79 @@
+import wiki.editors
+from django.forms import Textarea
+from wiki.editors.base import BaseEditor
+
+from ..base import RequireRootArticleMixin
+from ..base import WebTestBase
+from ..base import wiki_override_settings
+
+
+class CustomEditor(BaseEditor):
+    def get_widget(self, revision=None):
+        return Textarea(attrs={"data-revision": revision.pk})
+
+    def get_admin_widget(self, revision=None):
+        return Textarea(attrs={"data-revision": revision.pk})
+
+
+class EditorTest(RequireRootArticleMixin, WebTestBase):
+    def setUp(self):
+        super().setUp()
+        # reset the cached editor class and instance
+        wiki.editors._editor, wiki.editors._EditorClass = None, None
+
+    def test_editor_widget_markitup(self):
+        response = self.get_url("wiki:edit", path="")
+        self.assertContains(
+            response,
+            '<textarea name="content" class="markItUp" rows="10" cols="40" id="id_content">',
+        )
+
+    def test_admin_widget_markitup(self):
+        response = self.get_url(
+            "admin:wiki_articlerevision_change",
+            object_id=self.root_article.current_revision.id,
+        )
+        self.assertContains(
+            response,
+            '<textarea name="content" class="markItUp" rows="10" cols="40" id="id_content">',
+        )
+
+    @wiki_override_settings(WIKI_EDITOR="wiki.editors.base.BaseEditor")
+    def test_editor_widget_base(self):
+        response = self.get_url("wiki:edit", path="")
+        self.assertContains(
+            response, '<textarea name="content" cols="40" rows="10" id="id_content">'
+        )
+
+    @wiki_override_settings(WIKI_EDITOR="wiki.editors.base.BaseEditor")
+    def test_admin_widget_base(self):
+        response = self.get_url(
+            "admin:wiki_articlerevision_change",
+            object_id=self.root_article.current_revision.id,
+        )
+        self.assertContains(
+            response, '<textarea name="content" cols="40" rows="10" id="id_content">'
+        )
+
+    @wiki_override_settings(WIKI_EDITOR="tests.core.test_editor.CustomEditor")
+    def test_editor_widget_custom(self):
+        response = self.get_url("wiki:edit", path="")
+        self.assertContains(
+            response,
+            '<textarea name="content" cols="40" rows="10" data-revision="{}" id="id_content">'.format(
+                self.root_article.current_revision.id
+            ),
+        )
+
+    @wiki_override_settings(WIKI_EDITOR="tests.core.test_editor.CustomEditor")
+    def test_admin_widget_custom(self):
+        response = self.get_url(
+            "admin:wiki_articlerevision_change",
+            object_id=self.root_article.current_revision.id,
+        )
+        self.assertContains(
+            response,
+            '<textarea name="content" cols="40" rows="10" data-revision="{}" id="id_content">'.format(
+                self.root_article.current_revision.id
+            ),
+        )


### PR DESCRIPTION
Sometimes it is useful to have the current revision in the editor widget instance, for example to create preview and upload links, autocomplete, ...

<textarea name="content"
          data-upload-url='/wiki/my-page/_plugin/attachments/...'>

Previously, EditorBase had an instance attribute "instance", but that doesn't make sense (there is only one global instance of Editor) and wasn't ever filled anyway. This patch removes that, renames the "instance" parameter in get_widget()/get_admin_widget() to "revision" (to make clear what this parameter is) and fills it appropriately.