### PR TITLE
Add environments for py3.11 and dj4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ workflows:
           hatch_env: "py3.8-dj4.0"
           python_version: "3.8"
       - hatch:
+          hatch_env: "py3.8-dj-4.1"
+          python_version: "3.8"
+      - hatch:
           hatch_env: "py3.9-dj2.2"
           python_version: "3.9"
       - hatch:
@@ -73,9 +76,18 @@ workflows:
           hatch_env: "py3.9-dj4.0"
           python_version: "3.9"
       - hatch:
+          hatch_env: "py3.9-dj4.1"
+          python_version: "3.9"
+      - hatch:
           hatch_env: "py3.10-dj3.2"
           python_version: "3.10"
       - hatch:
           hatch_env: "py3.10-dj4.0"
           python_version: "3.10"
+      - hatch:
+          hatch_env: "py3.10-dj4.1"
+          python_version: "3.10"
+      - hatch:
+          hatch_env: "py3.11-dj4.1"
+          python_version: "3.11"
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,5 +89,5 @@ workflows:
           python_version: "3.10"
       - hatch:
           hatch_env: "py3.11-dj4.1"
-          python_version: "3.11"
+          python_version: "3.11.0"
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,17 +16,17 @@ jobs:
         type: string
     description: "Reusable job for invoking hatch"
     docker:
-      - image: circleci/python:<<parameters.python_version>>
+      - image: cimg/python:<<parameters.python_version>>
     steps:
       - checkout
       - run: pip install hatch && python -m hatch --env test.<<parameters.hatch_env>> run all
   lint:
     description: "Simple job for linting the pushed code"
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.9
     steps:
       - checkout
-      - run: pip install hatch && python -m hatch --env test.py3.8-dj4.0 run lint
+      - run: pip install hatch && python -m hatch --env test.py3.9-dj4.0 run lint
 
 workflows:
   main:
@@ -89,5 +89,5 @@ workflows:
           python_version: "3.10"
       - hatch:
           hatch_env: "py3.11-dj4.1"
-          python_version: "3.11.0"
+          python_version: "3.11"
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
           hatch_env: "py3.8-dj4.0"
           python_version: "3.8"
       - hatch:
-          hatch_env: "py3.8-dj-4.1"
+          hatch_env: "py3.8-dj4.1"
           python_version: "3.8"
       - hatch:
           hatch_env: "py3.9-dj2.2"

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,19 +1,20 @@
-**NOTE** Please use this option only if the discussions doesn't suit your needs.		
+**NOTE** Please use this option only if the discussions doesn't suit your needs.
 
-## Expected Behavior		
+## Expected Behavior
 
 Tell us what should happen...
 
-## Current Behavior		
+## Current Behavior
 
 Tell us what happens instead of the expected behavior...
 
-## Context (Environment)		
+## Context (Environment)
 
-* django-wiki version: ...		
-* Django version: ...		
-* Other details...		
+* django-wiki version: ...
+* Django version: ...
+* Python version: ...
+* Other details...
 
-## Details		
+## Details
 
-Please add logs or exception traces if relevant.		
+Please add logs or exception traces if relevant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,10 @@ django = ["3.2"]
 python = ["3.8", "3.9", "3.10"]
 django = ["4.0"]
 
+[[tool.hatch.envs.test.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11"]
+django = ["4.1"]
+
 [tool.hatch.envs.transifex]
 dependencies = [
     "transifex-client",


### PR DESCRIPTION
Since support for Python 3.11 was finally added in #1234, this is a continuation of the work and finally have a new version that supports Python 3.11 (#1243, #1232)