### PR TITLE
Fix Release Date for 0.10b1 in release_notes.rst

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -17,7 +17,7 @@ Release plan
 0.10b1
 ------
 
-Released on 2022-01-25
+Released on 2023-01-25
 
 Welcome onboard to new co-maintainer `Oscar Cortez <https://github.com/oscarmcm>`__ 🎉️
 


### PR DESCRIPTION
I think the year was not set correctly in this place.