### PR TITLE
Update TOC macro to enable feature parity with Article List

### DIFF
--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -91,8 +91,36 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
     toc.meta = {
         "short_description": _("Table of contents"),
         "help_text": _("Insert a table of contents matching the headings."),
-        "example_code": "[TOC]",
-        "args": {},
+        "example_code": "[TOC] or [TOC toc_depth:1]",
+        "args": {
+            "title": _(
+                "Title to insert in the Table of Contents’ <div>. Defaults to Contents."
+            ),
+            "baselevel": _("Base level for headers. Defaults to 1."),
+            "separator": _(
+                "Word separator. Character which replaces white space in id. Defaults to “-”."
+            ),
+            "anchorlink": _(
+                "Set to True to cause all headers to link to themselves. Default is False."
+            ),
+            "anchorlink_class": _(
+                "CSS class(es) used for the link. Defaults to toclink."
+            ),
+            "permalink": _(
+                "Set to True or a string to generate permanent links at the end of each header. Useful with Sphinx style sheets."
+            ),
+            "permalink_class": _(
+                "CSS class(es) used for the link. Defaults to headerlink."
+            ),
+            "permalink_title": _(
+                "Title attribute of the permanent link. Defaults to Permanent link."
+            ),
+            "toc_depth": _(
+                "Define the range of section levels to include in the Table of Contents. A single integer (b) defines the bottom section "
+                "level (<h1>..<hb>) only. A string consisting of two digits separated by a hyphen in between ('2-5'), define the top (t) "
+                "and the bottom (b) (<ht>..<hb>). Defaults to 6 (bottom)."
+            ),
+        },
     }
 
     def wikilink(self):

--- a/src/wiki/plugins/macros/mdx/macro.py
+++ b/src/wiki/plugins/macros/mdx/macro.py
@@ -5,6 +5,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
 from wiki.core.markdown import add_to_registry
 from wiki.plugins.macros import settings
+from wiki.plugins.macros.mdx import toc
 
 # See:
 # http://stackoverflow.com/questions/430759/regex-for-managing-escaped-characters-for-items-like-string-literals
@@ -40,7 +41,7 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
         )
 
     def handleMatch(self, m):
-        macro = m.group("macro").strip()
+        macro = m.group("macro").strip().lower()
         if macro not in settings.METHODS or not hasattr(self, macro):
             return m.group(2)
 
@@ -83,7 +84,8 @@ class MacroPattern(markdown.inlinepatterns.Pattern):
         "args": {"depth": _("Maximum depth to show levels for.")},
     }
 
-    def toc(self):
+    def toc(self, **kwargs):
+        toc.WikiTreeProcessorClass.CACHED_KWARGS = kwargs
         return "[TOC]"
 
     toc.meta = {

--- a/src/wiki/plugins/macros/mdx/toc.py
+++ b/src/wiki/plugins/macros/mdx/toc.py
@@ -17,23 +17,14 @@ def process_toc_depth(toc_depth):
 
 def process_bool_value(bool_val, org_val):
     if type(bool_val) is str:
-        if bool_val.lower() == "false":
+        if bool_val.lower() == "false" or bool_val == "0":
             return False
-        elif bool_val.lower() == "true":
+        elif bool_val.lower() == "true" or bool_val == "1":
             return True
         else:
             return org_val
-    elif type(bool_val) is int:
-        if bool_val == 1:
-            return True
-        elif bool_val == 0:
-            return False
-        else:
-            return org_val
-    elif type(bool_val) is bool:
-        return bool_val
     else:
-        return org_val
+        return process_bool_value(str(bool_val), org_val)
 
 
 def process_value(org_val, new_val):

--- a/src/wiki/plugins/macros/mdx/toc.py
+++ b/src/wiki/plugins/macros/mdx/toc.py
@@ -7,12 +7,12 @@ HEADER_ID_PREFIX = "wiki-toc-"
 
 
 def process_toc_depth(toc_depth):
-    if isinstance(toc_depth, str) and '-' in toc_depth:
-        toc_top, toc_bottom = [int(x) for x in toc_depth.split('-')]
+    if isinstance(toc_depth, str) and "-" in toc_depth:
+        toc_top, toc_bottom = [int(x) for x in toc_depth.split("-")]
     else:
         toc_top = 1
         toc_bottom = int(toc_depth)
-    return {'toc_top': toc_top, 'toc_bottom': toc_bottom}
+    return {"toc_top": toc_top, "toc_bottom": toc_bottom}
 
 
 def process_value(org_val, new_val):
@@ -31,9 +31,9 @@ def wiki_slugify(*args, **kwargs):
 
 
 class WikiTreeProcessorClass(TocTreeprocessor):
-    CACHED_KWARGS = dict()
+    CACHED_KWARGS = dict()  # Used to cache arguments parsed by the MacroPattern
+    # Used to map the keyword arguments to the Class Objects attribute name.
     TOC_CONFIG_VALUES = {
-        "marker": "marker",
         "title": "title",
         "baselevel": "base_level",
         "separator": "sep",
@@ -51,22 +51,39 @@ class WikiTreeProcessorClass(TocTreeprocessor):
         # Necessary because self.title is set to a LazyObject via gettext_lazy
         if self.title:
             self.title = str(self.title)
-        # Set config
+        # Set config and save defaults to tmp
         tmp_kwargs = dict()
         for k, v in WikiTreeProcessorClass.CACHED_KWARGS.items():
             if k in WikiTreeProcessorClass.TOC_CONFIG_VALUES:
                 if callable(WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]):
-                    for tock, tocv in WikiTreeProcessorClass.TOC_CONFIG_VALUES[k](v).items():
-                        tmp_kwargs[tock] = getattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[tock])
-                        setattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[tock], process_value(tmp_kwargs[tock], tocv))
+                    for tock, tocv in WikiTreeProcessorClass.TOC_CONFIG_VALUES[k](
+                        v
+                    ).items():
+                        tmp_kwargs[tock] = getattr(
+                            self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[tock]
+                        )
+                        setattr(
+                            self,
+                            WikiTreeProcessorClass.TOC_CONFIG_VALUES[tock],
+                            process_value(tmp_kwargs[tock], tocv),
+                        )
                 else:
-                    tmp_kwargs[WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]] = getattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[k])
-                    setattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[k], process_value(tmp_kwargs[WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]],v))
+                    tmp_kwargs[WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]] = getattr(
+                        self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]
+                    )
+                    setattr(
+                        self,
+                        WikiTreeProcessorClass.TOC_CONFIG_VALUES[k],
+                        process_value(
+                            tmp_kwargs[WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]], v
+                        ),
+                    )
         super().run(doc)
+        # Use tmp to reset values
         for k, v in tmp_kwargs.items():
             if hasattr(self, k):
                 setattr(self, k, v)
-        # Unset config
+        # Unset cached kwargs
         WikiTreeProcessorClass.CACHED_KWARGS = dict()
 
 

--- a/src/wiki/plugins/macros/mdx/toc.py
+++ b/src/wiki/plugins/macros/mdx/toc.py
@@ -16,23 +16,18 @@ def process_toc_depth(toc_depth):
 
 
 def process_bool_value(bool_val, org_val):
-    if type(bool_val) is str:
-        if bool_val.lower() == "false" or bool_val == "0":
-            return False
-        elif bool_val.lower() == "true" or bool_val == "1":
-            return True
-        else:
-            return org_val
+    if bool_val.lower() == "false" or bool_val == "0":
+        return False
+    elif bool_val.lower() == "true" or bool_val == "1":
+        return True
     else:
-        return process_bool_value(str(bool_val), org_val)
+        return org_val
 
 
 def process_value(org_val, new_val):
     try:
         if type(new_val) is str:
             new_val = new_val.lstrip("'").rstrip("'")
-        elif type(new_val) is not bool and type(new_val) is not int:
-            return org_val
 
         if type(org_val) is bool:
             return process_bool_value(new_val, org_val)
@@ -41,11 +36,9 @@ def process_value(org_val, new_val):
         elif type(org_val) is str:
             return new_val
         else:
-            new_val = org_val
+            return org_val
     except Exception:
         return org_val
-    else:
-        return new_val
 
 
 def wiki_slugify(*args, **kwargs):

--- a/src/wiki/plugins/macros/mdx/toc.py
+++ b/src/wiki/plugins/macros/mdx/toc.py
@@ -6,16 +6,68 @@ from wiki.plugins.macros import settings
 HEADER_ID_PREFIX = "wiki-toc-"
 
 
+def process_toc_depth(toc_depth):
+    if isinstance(toc_depth, str) and '-' in toc_depth:
+        toc_top, toc_bottom = [int(x) for x in toc_depth.split('-')]
+    else:
+        toc_top = 1
+        toc_bottom = int(toc_depth)
+    return {'toc_top': toc_top, 'toc_bottom': toc_bottom}
+
+
+def process_value(org_val, new_val):
+    try:
+        if type(new_val) is str:
+            new_val = new_val.lstrip("'").rstrip("'")
+        new_val = type(org_val)(new_val)
+    except Exception:
+        return org_val
+    else:
+        return new_val
+
+
 def wiki_slugify(*args, **kwargs):
     return HEADER_ID_PREFIX + slugify(*args, **kwargs)
 
 
 class WikiTreeProcessorClass(TocTreeprocessor):
+    CACHED_KWARGS = dict()
+    TOC_CONFIG_VALUES = {
+        "marker": "marker",
+        "title": "title",
+        "baselevel": "base_level",
+        "separator": "sep",
+        "anchorlink": "use_anchors",
+        "anchorlink_class": "anchorlink_class",
+        "permalink": "use_permalinks",
+        "permalink_class": "permalink_class",
+        "permalink_title": "permalink_title",
+        "toc_depth": process_toc_depth,
+        "toc_top": "toc_top",
+        "toc_bottom": "toc_bottom",
+    }
+
     def run(self, doc):
         # Necessary because self.title is set to a LazyObject via gettext_lazy
         if self.title:
             self.title = str(self.title)
+        # Set config
+        tmp_kwargs = dict()
+        for k, v in WikiTreeProcessorClass.CACHED_KWARGS.items():
+            if k in WikiTreeProcessorClass.TOC_CONFIG_VALUES:
+                if callable(WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]):
+                    for tock, tocv in WikiTreeProcessorClass.TOC_CONFIG_VALUES[k](v).items():
+                        tmp_kwargs[tock] = getattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[tock])
+                        setattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[tock], process_value(tmp_kwargs[tock], tocv))
+                else:
+                    tmp_kwargs[WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]] = getattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[k])
+                    setattr(self, WikiTreeProcessorClass.TOC_CONFIG_VALUES[k], process_value(tmp_kwargs[WikiTreeProcessorClass.TOC_CONFIG_VALUES[k]],v))
         super().run(doc)
+        for k, v in tmp_kwargs.items():
+            if hasattr(self, k):
+                setattr(self, k, v)
+        # Unset config
+        WikiTreeProcessorClass.CACHED_KWARGS = dict()
 
 
 class WikiTocExtension(TocExtension):

--- a/tests/plugins/macros/test_toc.py
+++ b/tests/plugins/macros/test_toc.py
@@ -1,7 +1,8 @@
-from markdown import Markdown
 from django.test import TestCase
-from wiki.plugins.macros.mdx.toc import WikiTocExtension
+from markdown import Markdown
 from wiki.core import markdown
+from wiki.plugins.macros.mdx.toc import WikiTocExtension
+
 from tests.base import RequireRootArticleMixin
 from tests.base import TestBase
 
@@ -39,7 +40,7 @@ class TocMacroTests(TestCase):
 
     def test_toc_renders_table_of_content_with_kwargs(self):
         """Verifies that the [TOC] wiki code renders a Table of Content"""
-        md = Markdown(extensions=["extra", WikiTocExtension(title='test')])
+        md = Markdown(extensions=["extra", WikiTocExtension(title="test")])
         text = (
             "[TOC]\n"
             "\n"
@@ -91,7 +92,7 @@ class TocMacroTestsInWiki(RequireRootArticleMixin, TestBase):
             "</div>\n"
             '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
-            '<p>Paragraph 1</p>\n'
+            "<p>Paragraph 1</p>\n"
             '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
             "<p>Paragraph 2</p>"
@@ -121,7 +122,7 @@ class TocMacroTestsInWiki(RequireRootArticleMixin, TestBase):
             "</div>\n"
             '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
-            '<p>Paragraph 1</p>\n'
+            "<p>Paragraph 1</p>\n"
             '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
             "<p>Paragraph 2</p>"
@@ -144,11 +145,11 @@ class TocMacroTestsInWiki(RequireRootArticleMixin, TestBase):
         expected_output = (
             '<div class="toc"><span class="toctitle">Contents</span><ul>\n'
             '<li><a href="#wiki-toc-first-title">First title.</a></li>\n'
-            '</ul>\n'
-            '</div>\n'
+            "</ul>\n"
+            "</div>\n"
             '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
-            '<p>Paragraph 1</p>\n'
+            "<p>Paragraph 1</p>\n"
             '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
             "<p>Paragraph 2</p>"
@@ -171,16 +172,16 @@ class TocMacroTestsInWiki(RequireRootArticleMixin, TestBase):
         expected_output = (
             '<div class="toc"><span class="toctitle">test</span><ul>\n'
             '<li><a href="#wiki-toc-first-title">First title.</a></li>\n'
-            '</ul>\n'
-            '</div>\n'
+            "</ul>\n"
+            "</div>\n"
             '<h1 id="wiki-toc-first-title"><a class="toclink" '
             'href="#wiki-toc-first-title">First title.</a><a '
             'class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
-            '<p>Paragraph 1</p>\n'
+            "<p>Paragraph 1</p>\n"
             '<h2 id="wiki-toc-subsection"><a class="toclink" '
             'href="#wiki-toc-subsection">Subsection</a><a class="article-edit-title-link" '
             'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
-            '<p>Paragraph 2</p>'
+            "<p>Paragraph 2</p>"
         )
         self.assertEqual(md.convert(text), expected_output)

--- a/tests/plugins/macros/test_toc.py
+++ b/tests/plugins/macros/test_toc.py
@@ -215,3 +215,99 @@ class TocMacroTestsInWiki(RequireRootArticleMixin, TestBase):
             "<p>Paragraph 2</p>"
         )
         self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_in_wiki_test_bool_one(self):
+        # Test if the integer is 1 and should be True
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC anchorlink:1]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">Contents</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            "</ul>\n"
+            "</li>\n"
+            "</ul>\n"
+            "</div>\n"
+            '<h1 id="wiki-toc-first-title"><a class="toclink" '
+            'href="#wiki-toc-first-title">First title.</a><a '
+            'class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            "<p>Paragraph 1</p>\n"
+            '<h2 id="wiki-toc-subsection"><a class="toclink" '
+            'href="#wiki-toc-subsection">Subsection</a><a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_in_wiki_test_bool_zero(self):
+        # Test if the integer is zero and should be false
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC anchorlink:0]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">Contents</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            "</ul>\n"
+            "</li>\n"
+            "</ul>\n"
+            "</div>\n"
+            '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            "<p>Paragraph 1</p>\n"
+            '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_in_wiki_test_bool_wrong(self):
+        # Test if the integer is wrong value
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC anchorlink:5]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">Contents</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            "</ul>\n"
+            "</li>\n"
+            "</ul>\n"
+            "</div>\n"
+            '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            "<p>Paragraph 1</p>\n"
+            '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)

--- a/tests/plugins/macros/test_toc.py
+++ b/tests/plugins/macros/test_toc.py
@@ -1,12 +1,15 @@
-import markdown
+from markdown import Markdown
 from django.test import TestCase
 from wiki.plugins.macros.mdx.toc import WikiTocExtension
+from wiki.core import markdown
+from tests.base import RequireRootArticleMixin
+from tests.base import TestBase
 
 
 class TocMacroTests(TestCase):
     def test_toc_renders_table_of_content(self):
         """Verifies that the [TOC] wiki code renders a Table of Content"""
-        md = markdown.Markdown(extensions=["extra", WikiTocExtension()])
+        md = Markdown(extensions=["extra", WikiTocExtension()])
         text = (
             "[TOC]\n"
             "\n"
@@ -31,5 +34,153 @@ class TocMacroTests(TestCase):
             "<p>Paragraph 1</p>\n"
             '<h2 id="wiki-toc-subsection">Subsection</h2>\n'
             "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_with_kwargs(self):
+        """Verifies that the [TOC] wiki code renders a Table of Content"""
+        md = Markdown(extensions=["extra", WikiTocExtension(title='test')])
+        text = (
+            "[TOC]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">test</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            "</ul>\n"
+            "</li>\n"
+            "</ul>\n"
+            "</div>\n"
+            '<h1 id="wiki-toc-first-title">First title.</h1>\n'
+            "<p>Paragraph 1</p>\n"
+            '<h2 id="wiki-toc-subsection">Subsection</h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)
+
+
+class TocMacroTestsInWiki(RequireRootArticleMixin, TestBase):
+    def test_toc_renders_table_of_content_in_wiki(self):
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">Contents</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            "</ul>\n"
+            "</li>\n"
+            "</ul>\n"
+            "</div>\n"
+            '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            '<p>Paragraph 1</p>\n'
+            '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_in_wiki_with_kwargs(self):
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC title:test]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">test</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            "</ul>\n"
+            "</li>\n"
+            "</ul>\n"
+            "</div>\n"
+            '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            '<p>Paragraph 1</p>\n'
+            '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_in_wiki_with_depth(self):
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC toc_depth:1]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">Contents</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a></li>\n'
+            '</ul>\n'
+            '</div>\n'
+            '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            '<p>Paragraph 1</p>\n'
+            '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_in_wiki_with_multi_kwargs(self):
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC title:'test' toc_depth:'1' anchorlink:'True']\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">test</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a></li>\n'
+            '</ul>\n'
+            '</div>\n'
+            '<h1 id="wiki-toc-first-title"><a class="toclink" '
+            'href="#wiki-toc-first-title">First title.</a><a '
+            'class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            '<p>Paragraph 1</p>\n'
+            '<h2 id="wiki-toc-subsection"><a class="toclink" '
+            'href="#wiki-toc-subsection">Subsection</a><a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            '<p>Paragraph 2</p>'
         )
         self.assertEqual(md.convert(text), expected_output)

--- a/tests/plugins/macros/test_toc.py
+++ b/tests/plugins/macros/test_toc.py
@@ -185,3 +185,33 @@ class TocMacroTestsInWiki(RequireRootArticleMixin, TestBase):
             "<p>Paragraph 2</p>"
         )
         self.assertEqual(md.convert(text), expected_output)
+
+    def test_toc_renders_table_of_content_in_wiki_wrong_type(self):
+        md = markdown.ArticleMarkdown(article=self.root_article)
+        text = (
+            "[TOC anchorlink:Yes]\n"
+            "\n"
+            "# First title.\n"
+            "\n"
+            "Paragraph 1\n"
+            "\n"
+            "## Subsection\n"
+            "\n"
+            "Paragraph 2"
+        )
+        expected_output = (
+            '<div class="toc"><span class="toctitle">Contents</span><ul>\n'
+            '<li><a href="#wiki-toc-first-title">First title.</a><ul>\n'
+            '<li><a href="#wiki-toc-subsection">Subsection</a></li>\n'
+            "</ul>\n"
+            "</li>\n"
+            "</ul>\n"
+            "</div>\n"
+            '<h1 id="wiki-toc-first-title">First title.<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-first-title/">[edit]</a></h1>\n'
+            "<p>Paragraph 1</p>\n"
+            '<h2 id="wiki-toc-subsection">Subsection<a class="article-edit-title-link" '
+            'href="/_plugin/editsection/header/wiki-toc-subsection/">[edit]</a></h2>\n'
+            "<p>Paragraph 2</p>"
+        )
+        self.assertEqual(md.convert(text), expected_output)


### PR DESCRIPTION
This is a rough draft attempt to resolve Issue: https://github.com/django-wiki/django-wiki/issues/1042

This is inspired by the existing code here: https://github.com/django-wiki/django-wiki/blob/918b354aabf23ae7c1612e9ac746d7c7905c137b/src/wiki/plugins/macros/mdx/toc.py#L16

It caches keyword arguments parsed by the MacroPattern class to a class variable in WikiTreeProcessorClass. Then the 'run' method maps these keyword arguments to the object's attributes before running 'super().run(doc)'. Afterward, it takes a tmp dictionary with the attribute's original values sets, then back and resets the cache that was set by MacroPattern.

I have attempted to follow the instructions for contributing. I used hatch test and lint before submitting, and I added several new tests for TOC. 

**NOTE**: The original tests for TOC didn't test TOC within django-wiki but instead simply tested that the Markdown TOC extension still worked. While this is nice to make sure that this 3rd party dependency maintains this feature as new versions are supported, this doesn't do a good feature test. I may have adjusted the test_toc.py file in a way that is not standard but hopefully will do a better job of testing with all the extensions registered.

Problems to consider: 
What if an exception happens? Perhaps the super().run(doc) should be within a try block with a finally undoing variables. Thoughts?  
