### PR TITLE
Update settings.py to allow align attributes in td tags

### DIFF
--- a/src/wiki/conf/settings.py
+++ b/src/wiki/conf/settings.py
@@ -98,6 +98,7 @@ for tag in MARKDOWN_HTML_WHITELIST:
 
 _default_attribute_whitelist["img"].append("src")
 _default_attribute_whitelist["img"].append("alt")
+_default_attribute_whitelist["td"].append("align")
 
 #: Dictionary of allowed attributes in Markdown article contents.
 MARKDOWN_HTML_ATTRIBUTES = _default_attribute_whitelist


### PR DESCRIPTION
One line change in wiki/conf/settings.py to add "align" as a permitted attribute for td tags.