### PR TITLE
Demo: Only display demo message once

### DIFF
--- a/testproject/testproject/fixtures/fixtures.json
+++ b/testproject/testproject/fixtures/fixtures.json
@@ -173,7 +173,9 @@
       "fields": {
           "user": 1,
           "interval": 0,
-          "is_default": true
+          "is_default": true,
+          "created": "2023-01-31T22:18:24Z",
+          "modified": "2023-01-31T22:18:24Z"
       }
   },
   {
@@ -182,7 +184,9 @@
       "fields": {
           "user": 2,
           "interval": 0,
-          "is_default": true
+          "is_default": true,
+          "created": "2023-01-31T22:18:24Z",
+          "modified": "2023-01-31T22:18:24Z"
       }
   },
   {
@@ -193,7 +197,10 @@
           "notification_type": "article_edit",
           "object_id": "1",
           "send_emails": true,
-          "latest": null
+          "latest": null,
+          "created": "2023-01-31T22:18:24Z",
+          "modified": "2023-01-31T22:18:24Z",
+          "last_sent": null
       }
   },
   {

--- a/testproject/testproject/middleware.py
+++ b/testproject/testproject/middleware.py
@@ -13,9 +13,19 @@ class DemoMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+
         # Code to be executed for each request before
         # the view (and later middleware) are called.
-        messages.add_message(request, messages.WARNING, MSG)
+        demo_message_exists = False
+        storage = messages.get_messages(request)
+        for message in storage:
+            if str(message) == MSG:
+                demo_message_exists = True
+        storage.used = False
+        print(demo_message_exists)
+        if not demo_message_exists:
+            messages.add_message(request, messages.WARNING, MSG)
+
         response = self.get_response(request)
 
         # Code to be executed for each request/response after

--- a/testproject/testproject/settings/dev.py
+++ b/testproject/testproject/settings/dev.py
@@ -1,4 +1,5 @@
 from .base import *  # noqa @UnusedWildImport
+from .demo import *  # noqa @UnusedWildImport
 
 DEBUG = True
 


### PR DESCRIPTION
Kept seeing this message 2-3-4 times on the demo. It must be something about how middleware works in relation to how many requests are made through the middleware before calling `get_messages` from the template.

I think if you call the middleware 3 times before ultimately rendering the template, the message is added 3 times before it's consumed.