### PR TITLE
Fix history info on logged IPs for anonymous users

### DIFF
--- a/src/wiki/templates/wiki/includes/revision_info.html
+++ b/src/wiki/templates/wiki/includes/revision_info.html
@@ -7,7 +7,7 @@
 
 
 {% load wiki_tags i18n %}
-{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user %}{{ revision.ip_address|default:"anonymous (IP not logged)" }}{% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
+{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user or not revision.ip_address %}{{ revision.ip_address|default:"anonymous (IP not logged)" }}{% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
 {% if revision == current_revision %}
   <strong>*</strong>
 {% endif %}


### PR DESCRIPTION
Currently, if the setting `LOG_IPS_ANONYMOUS` is set to `False` no IPs are logged for anonymous users (as expected). But the article history still shows "by anonymous (IP logged)". Instead, the entry should show "by anonymous (IP not logged)".

This PR adds an additional check in the template if an IP address is set in the revision and thus enables the right branch in the template.

(Side note: This is my first PR with absolutely no prior knowledge of this code base so there might be a better way, but I tried my best!)