### PR TITLE
Another instance of using safe incorrectly

### DIFF
--- a/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/search.html
+++ b/src/wiki/plugins/attachments/templates/wiki/plugins/attachments/search.html
@@ -34,7 +34,7 @@
   <tr>
     <td>
       <h4>{{ attachment.original_filename }}</h4>
-      {{ attachment.current_revision.description|default:_("<em>No description</em>")|safe }}
+      {% if attachment.current_revision.description %}{{ attachment.current_revision.description }}{% else %}<em>{% trans "No description" %}</em>{% endif %}
     </td>
     <td>
       <strong>{{ attachment.article.current_revision.title }}</strong>


### PR DESCRIPTION
If someone managed to get something malicious into the DB we display it in the template. Similar issue to https://github.com/django-wiki/django-wiki/security/advisories/GHSA-f8hx-4ghf-5wg2