### PR TITLE
Allow pymdown-extensions 10.x to unblock security releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,11 @@ dependencies = [
     # several extensions have imported internal APIs, so be very
     # careful here.
     "Markdown>=3.4,<3.10",
-    # Set of extensions for Python Markdown.
-    "pymdown-extensions>=10.5,<10.6",
+    # Set of extensions for Python Markdown. The previous <10.6 cap blocked
+    # security releases (e.g. the 10.16.1 ReDoS and 10.21.3 path-traversal
+    # fixes). Only the stable pymdownx.blocks.* extensions are used and their
+    # output is unchanged across 10.5..10.21, so allow the whole 10.x series.
+    "pymdown-extensions>=10.5,<11",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

The `pymdown-extensions>=10.5,<10.6` cap pins the package to **10.5**, which is affected by published advisories whose fixes only landed in later `10.x` releases. The tight upper bound leaves django-wiki users with **unfixable Dependabot alerts and no upgrade path**, as reported in #1415 (and in line with the broader request in #1408).

Affected releases that the cap currently blocks:

- **ReDoS** in `pymdownx.blocks.caption` — fixed in **10.16.1** (facelessuser/pymdown-extensions#2716)
- **Path traversal** in `pymdownx.snippets` — fixed in **10.21.3** (GHSA-62q4-447f-wv8h / CVE-2026-46338)

This PR widens the constraint to the whole `10.x` series while keeping a major-version guard, consistent with the project's per-dependency pinning philosophy:

```diff
-    "pymdown-extensions>=10.5,<10.6",
+    "pymdown-extensions>=10.5,<11",
```

## Why this is safe

django-wiki only consumes the stable `pymdownx.blocks.*` extensions (`admonition`, `definition`, `html`, `details`) via the `pymdown` plugin. Their rendered HTML output is unchanged from 10.5 through 10.21.3.

## Test plan

- [x] `pytest tests/plugins/pymdown/` passes against `pymdown-extensions==10.21.3` (17/17)
- [x] Rendered output of every block-extension test input is byte-identical between 10.5 and 10.21.3
- [x] Remainder of the suite is unaffected by the bump (the only failures in my environment — `tests/core/test_markdown.py::CodehiliteTests` — are caused by the local Pygments version and fail identically on 10.5, so they are unrelated to this change)

Closes #1415